### PR TITLE
Assert package for simple testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Where `[pkg]` is the name of the package you want to use in your project. Note t
 
 This is single repository that stores many, independent small subpackages. This list changes often as common code gets moved from specific projects into this repository.
 
+- [assert](assert/): simple test assertions for no-dependency testing
 - [out](out/): hierarchical logger to manage logging verbosity to stdout
 - [noplog](noplog/): no operation logger to capture internal logging with no output
 

--- a/assert/README.md
+++ b/assert/README.md
@@ -1,0 +1,30 @@
+# Assertion Helpers
+
+Because this is a library, we prefer to have no dependencies including our usual test
+dependencies (e.g. testify require). So we have some basic assertion helpers for tests.
+
+See: https://github.com/benbjohnson/testing
+
+Usage:
+
+```go
+import "go.rtnl.ai/x/assert"
+
+func TestMyFunc(t *testing.T) {
+    // Basic assertion of a condition
+    assert.Assert(t, 2+2 == 4, "ensure addition works")
+
+    // Assert true or false
+    assert.True(t, 2+2 == 4, "should be equal")
+    assert.False(t, 2+1 == 4, "should not be equal")
+
+    // For a function that returns an error, ensure no error is returned
+    assert.Ok(t, MyFunc(), "expected error to be nil")
+
+    // Test equality
+    assert.Equals(t, expected, actual)
+
+    // Test the error is a specific error target
+    assert.ErrorIs(t, err, MyError)
+}
+```

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,0 +1,62 @@
+/*
+Assertion Helpers
+
+Because this is a library, we prefer to have no dependencies including our usual test
+dependencies (e.g. testify require). So we have some basic assertion helpers for tests.
+
+See: https://github.com/benbjohnson/testing
+*/
+package assert
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	tb.Helper()
+	if !condition {
+		tb.Logf("\n"+msg+"\n", v...)
+		tb.FailNow()
+	}
+}
+
+type BoolAssertion func(testing.TB, bool)
+
+// True asserts that the condition is true.
+func True(tb testing.TB, condition bool) {
+	tb.Helper()
+	Assert(tb, condition, "expected condition to be true")
+}
+
+// False asserts that the condition is false.
+func False(tb testing.TB, condition bool) {
+	tb.Helper()
+	Assert(tb, !condition, "expected condition to be false")
+}
+
+// Ok fails the test if an err is not nil.
+func Ok(tb testing.TB, err error) {
+	tb.Helper()
+	if err != nil {
+		tb.Logf("\nunexpected error: %q\n", err.Error())
+		tb.FailNow()
+	}
+}
+
+// Equals fails the test if exp (expected) is not equal to act (actual).
+func Equals(tb testing.TB, exp, act interface{}) {
+	tb.Helper()
+	if !reflect.DeepEqual(exp, act) {
+		tb.Logf("\nactual value did not match expected:\n\n\t- exp: %#v\n\t- got: %#v\n", exp, act)
+		tb.FailNow()
+	}
+}
+
+// ErrorIs fails the test if the err does not match the target.
+func ErrorIs(tb testing.TB, err, target error) {
+	tb.Helper()
+	Assert(tb, errors.Is(err, target), "expected target to be in error chain")
+}


### PR DESCRIPTION
This PR adds a simple `assert` helper package for writing tests for libraries where we don't want large test package dependencies. 