### PR TITLE
base58 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is single repository that stores many, independent small subpackages. This 
 - [probez](https://go.rtnl.ai/x/probez): http handlers for kubernetes probes (livez, healthz, and readyz)
 - [gravatar](https://go.rtnl.ai/x/gravatar): helper to create Gravatar urls from email addresses
 - [humanize](https://go.rtnl.ai/x/humanize): creates human readable strings from various types
+- [base58](https://go.rtnl.ai/x/base58): base58 encoding package as used by Bitcoin and travel addresses
 
 ## About
 

--- a/base58/README.md
+++ b/base58/README.md
@@ -1,0 +1,32 @@
+# Base58
+
+Base58 is a binary-to-text encoding scheme that uses an alphabet of 58 characters to represent data and is commonly used in Bitcoin and with Travel Addresses. The alphabet chosen purposefully avoids similar looking letters, therefore it is useful for things that have to be read out loud by humans. However it is more inefficient than base64 because it has fewer characters and parsing is more awkward because the base is not a power of 2.
+
+This library was ported from [github.com/trisacrypto/trisa/pkg/openvasp/traddr](https://pkg.go.dev/github.com/trisacrypto/trisa/pkg/openvasp/traddr).
+
+Use the `Encode` and `Decode` functions for simple base58 handling:
+
+```go
+data := []byte{193, 65, 211, 109, 255, 213, 186, 58, 6, 122, 175, 146, 99, 34, 19, 124}
+encoded := base58.Encode(data)
+decoded := base58.Decode(encoded)
+
+bytes.Equal(data, decoded)
+// true
+```
+
+Note that `Decode` will not report any errors, if it encounters a problem it will just return an empty byte array. Because of that, it is recommended that you use `CheckEncode` and `CheckDecode` which also adds a version number and a checksum to the decoding process:
+
+```go
+data := []byte{193, 65, 211, 109, 255, 213, 186, 58, 6, 122, 175, 146, 99, 34, 19, 124}
+encoded := base58.CheckEncode(data)
+decoded, err := base58.CheckDecode(encoded)
+
+err == nil
+// true
+
+bytes.Equal(data, decoded)
+// true
+```
+
+This will result in a slightly longer encoding, but the checksum will ensure the data has not been corrupted when decoding.

--- a/base58/base58.go
+++ b/base58/base58.go
@@ -1,0 +1,232 @@
+/*
+Base58 is a binary-to-text encoding scheme that uses an alphabet of 58 characters to
+represent data and is commonly used in Bitcoin and with Travel Addresses. The alphabet
+chosen purposefully avoids similar looking letters, therefore it is useful for things
+that have to be read out loud by humans. However it is more inefficient than base64
+because it has fewer characters and parsing is more awkward because the base is not a
+power of 2.
+
+This library was ported from github.com/trisacrypto/trisa/pkg/openvasp/traddr
+*/
+package base58
+
+import (
+	"crypto/sha256"
+	"errors"
+	"math/big"
+)
+
+const (
+	// Alphabet is the modified base58 alphabet used by Bitcoin.
+	Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+	alphabetIdx0 = '1'
+)
+
+var (
+	// ErrChecksum indicates that the checksum of a check-encoded string does not
+	// verify against the checksum.
+	ErrChecksum = errors.New("checksum error")
+
+	// ErrInvalidFormat indicates that the check-encoded string has an invalid format.
+	ErrInvalidFormat = errors.New("invalid format: version and/or checksum bytes missing")
+)
+
+var b58 = [256]byte{
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 0, 1, 2, 3, 4, 5, 6,
+	7, 8, 255, 255, 255, 255, 255, 255,
+	255, 9, 10, 11, 12, 13, 14, 15,
+	16, 255, 17, 18, 19, 20, 21, 255,
+	22, 23, 24, 25, 26, 27, 28, 29,
+	30, 31, 32, 255, 255, 255, 255, 255,
+	255, 33, 34, 35, 36, 37, 38, 39,
+	40, 41, 42, 43, 255, 44, 45, 46,
+	47, 48, 49, 50, 51, 52, 53, 54,
+	55, 56, 57, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+	255, 255, 255, 255, 255, 255, 255, 255,
+}
+
+var bigRadix = [...]*big.Int{
+	big.NewInt(0),
+	big.NewInt(58),
+	big.NewInt(58 * 58),
+	big.NewInt(58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58 * 58 * 58),
+	bigRadix10,
+}
+
+var bigRadix10 = big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58 * 58 * 58 * 58) // 58^10
+
+// CheckDecode decodes a string that was encoded with CheckEncode and verifies the checksum.
+func CheckDecode(input string) (result []byte, err error) {
+	decoded := Decode(input)
+	if len(decoded) < 5 {
+		return nil, ErrInvalidFormat
+	}
+	var cksum [4]byte
+	copy(cksum[:], decoded[len(decoded)-4:])
+	if checksum(decoded[:len(decoded)-4]) != cksum {
+		return nil, ErrChecksum
+	}
+	payload := decoded[0 : len(decoded)-4]
+	result = append(result, payload...)
+	return
+}
+
+// Decode decodes a modified base58 string to a byte slice.
+func Decode(b string) []byte {
+	answer := big.NewInt(0)
+	scratch := new(big.Int)
+
+	// Calculating with big.Int is slow for each iteration.
+	//    x += b58[b[i]] * j
+	//    j *= 58
+	//
+	// Instead we can try to do as much calculations on int64.
+	// We can represent a 10 digit base58 number using an int64.
+	//
+	// Hence we'll try to convert 10, base58 digits at a time.
+	// The rough idea is to calculate `t`, such that:
+	//
+	//   t := b58[b[i+9]] * 58^9 ... + b58[b[i+1]] * 58^1 + b58[b[i]] * 58^0
+	//   x *= 58^10
+	//   x += t
+	//
+	// Of course, in addition, we'll need to handle boundary condition when `b` is not multiple of 58^10.
+	// In that case we'll use the bigRadix[n] lookup for the appropriate power.
+	for t := b; len(t) > 0; {
+		n := len(t)
+		if n > 10 {
+			n = 10
+		}
+
+		total := uint64(0)
+		for _, v := range t[:n] {
+			if v > 255 {
+				return []byte("")
+			}
+
+			tmp := b58[v]
+			if tmp == 255 {
+				return []byte("")
+			}
+			total = total*58 + uint64(tmp)
+		}
+
+		answer.Mul(answer, bigRadix[n])
+		scratch.SetUint64(total)
+		answer.Add(answer, scratch)
+
+		t = t[n:]
+	}
+
+	tmpval := answer.Bytes()
+
+	var numZeros int
+	for numZeros = 0; numZeros < len(b); numZeros++ {
+		if b[numZeros] != alphabetIdx0 {
+			break
+		}
+	}
+	flen := numZeros + len(tmpval)
+	val := make([]byte, flen)
+	copy(val[numZeros:], tmpval)
+
+	return val
+}
+
+// CheckEncode prepends a version byte and appends a four byte checksum.
+func CheckEncode(input []byte) string {
+	b := make([]byte, 0, len(input)+4)
+	b = append(b, input...)
+	cksum := checksum(b)
+	b = append(b, cksum[:]...)
+	return Encode(b)
+}
+
+// Encode encodes a byte slice to a modified base58 string.
+func Encode(b []byte) string {
+	x := new(big.Int)
+	x.SetBytes(b)
+
+	// maximum length of output is log58(2^(8*len(b))) == len(b) * 8 / log(58)
+	maxlen := int(float64(len(b))*1.365658237309761) + 1
+	answer := make([]byte, 0, maxlen)
+	mod := new(big.Int)
+	for x.Sign() > 0 {
+		// Calculating with big.Int is slow for each iteration.
+		//    x, mod = x / 58, x % 58
+		//
+		// Instead we can try to do as much calculations on int64.
+		//    x, mod = x / 58^10, x % 58^10
+		//
+		// Which will give us mod, which is 10 digit base58 number.
+		// We'll loop that 10 times to convert to the answer.
+
+		x.DivMod(x, bigRadix10, mod)
+		if x.Sign() == 0 {
+			// When x = 0, we need to ensure we don't add any extra zeros.
+			m := mod.Int64()
+			for m > 0 {
+				answer = append(answer, Alphabet[m%58])
+				m /= 58
+			}
+		} else {
+			m := mod.Int64()
+			for i := 0; i < 10; i++ {
+				answer = append(answer, Alphabet[m%58])
+				m /= 58
+			}
+		}
+	}
+
+	// leading zero bytes
+	for _, i := range b {
+		if i != 0 {
+			break
+		}
+		answer = append(answer, alphabetIdx0)
+	}
+
+	// reverse
+	alen := len(answer)
+	for i := 0; i < alen/2; i++ {
+		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
+	}
+
+	return string(answer)
+}
+
+// checksum: first four bytes of sha256^2
+func checksum(input []byte) (cksum [4]byte) {
+	h := sha256.Sum256(input)
+	h2 := sha256.Sum256(h[:])
+	copy(cksum[:], h2[:4])
+	return
+}

--- a/base58/base58_test.go
+++ b/base58/base58_test.go
@@ -1,0 +1,106 @@
+package base58_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"go.rtnl.ai/x/assert"
+	"go.rtnl.ai/x/base58"
+)
+
+func ExampleEncode() {
+	data := []byte{193, 65, 211, 109, 255, 213, 186, 58, 6, 122, 175, 146, 99, 34, 19, 124}
+	encoded := base58.Encode(data)
+	fmt.Println(encoded)
+	// Output:
+	// Qs8DeAwbRJyRQjFXwm34pT
+}
+
+func ExampleDecode() {
+	decoded := base58.Decode("Qs8DeAwbRJyRQjFXwm34pT")
+	fmt.Println(decoded)
+	// Output:
+	// [193 65 211 109 255 213 186 58 6 122 175 146 99 34 19 124]
+}
+
+func ExampleCheckEncode() {
+	data := []byte{193, 65, 211, 109, 255, 213, 186, 58, 6, 122, 175, 146, 99, 34, 19, 124}
+	encoded := base58.CheckEncode(data)
+	fmt.Println(encoded)
+	// Output:
+	// 3hADuDuUNzTmuQZJPhELsYw6mqFD
+}
+
+func ExampleCheckDecode() {
+	decoded, err := base58.CheckDecode("3hADuDuUNzTmuQZJPhELsYw6mqFD")
+	fmt.Println(decoded, err)
+	// Output:
+	// [193 65 211 109 255 213 186 58 6 122 175 146 99 34 19 124] <nil>
+}
+
+func TestBase58(t *testing.T) {
+	sizes := []int{2, 8, 16, 32, 64, 128, 256, 512, 1024, 4096}
+	for _, size := range sizes {
+		orig := randBytes(t, size)
+		encoded := base58.CheckEncode(orig)
+		decoded, err := base58.CheckDecode(encoded)
+		assert.Ok(t, err, "could not decode the encoded base58 string")
+		assert.True(t, bytes.Equal(orig, decoded), "decoded does not match original bytes")
+	}
+}
+
+func TestBase58Empty(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		// NOTE: check decode will fail
+		assert.Equal(t, "", base58.Encode(nil))
+		assert.Equal(t, "3QJmnh", base58.CheckEncode(nil))
+		assert.Equal(t, []byte{}, base58.Decode(""))
+	})
+
+	t.Run("Array", func(t *testing.T) {
+		// NOTE: check decode will fail
+		assert.Equal(t, "", base58.Encode([]byte{}))
+		assert.Equal(t, "3QJmnh", base58.CheckEncode([]byte{}))
+		assert.Equal(t, []byte{}, base58.Decode(""))
+	})
+}
+
+func TestBase58IncorrectDecode(t *testing.T) {
+	// This should not panic but return an empty array
+	out := base58.Decode("foo+90?")
+	assert.Equal(t, out, []byte{})
+}
+
+func TestBase58IncorrectCheckDecode(t *testing.T) {
+	testCases := []struct {
+		input string
+		err   error
+	}{
+		{
+			"3QJmnh", base58.ErrInvalidFormat, // This is the zero-valued array case
+		},
+		{
+			"+9quc2?~", base58.ErrInvalidFormat, // Invalid characters in alphabet
+		},
+		{
+			"", base58.ErrInvalidFormat, // Empty strings have no checksums
+		},
+		{
+			"Qs8DeAwbRJyRQjFXwm34pT", base58.ErrChecksum, // Bad Checksum
+		},
+	}
+
+	for i, tc := range testCases {
+		_, err := base58.CheckDecode(tc.input)
+		assert.ErrorIs(t, err, tc.err, "test case %d did not return expected error", i)
+	}
+}
+
+func randBytes(t *testing.T, n int) []byte {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	assert.Ok(t, err, "could not generate %d random bytes", n)
+	return b
+}


### PR DESCRIPTION
### Scope of changes

Adds base58 encoding to the `x` library which uses a binary to string encoding scheme that omits characters that look similar to each other. Useful when a human has to read the encoding out loud.

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?