### PR TITLE
Typecase Library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go.rtnl.ai/x
 
 go 1.23.3
+
+require golang.org/x/text v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
+golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=

--- a/typecase/README.md
+++ b/typecase/README.md
@@ -1,0 +1,32 @@
+# Typecase
+
+Allows you to switch between CamelCase, lowerCamelCase, snake_case, kebab-case, and CONSTANT_CASE. This code is generally used in our template functions for HTML, code generation tools, or for portability between langauges or different JSON representations of keys.
+
+Features:
+
+- Handles unicode
+- Keeps common acronyms and parts together such as `ID` or `HTTP`
+
+## Usage
+
+```go
+import (
+    "fmt"
+
+    "go.rtnl.x/typecase"
+)
+
+input := "a_StringTo TYPE_CASE"
+
+// Convert to different cases!
+fmt.Println(casing.Camel(input))
+fmt.Println(casing.LowerCamel(input))
+fmt.Println(casing.Snake(input))
+```
+
+## Inspiration
+
+Thanks to the following libraries for inspiration:
+
+- [danielgtaylor/casing](https://github.com/danielgtaylor/casing)
+- [gobeam/stringy](https://github.com/gobeam/stringy)

--- a/typecase/state.go
+++ b/typecase/state.go
@@ -1,0 +1,12 @@
+package typecase
+
+// State machine for handling split algorithm.
+type state uint8
+
+const (
+	stateNone state = iota
+	stateLower
+	stateFirstUpper
+	stateUpper
+	stateSymbol
+)

--- a/typecase/typecase.go
+++ b/typecase/typecase.go
@@ -1,0 +1,244 @@
+package typecase
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var (
+	initialisms = []string{
+		// Borrowed from Staticcheck (https://github.com/dominikh/go-tools/blob/master/config/config.go#L167)
+		"ACL", "API", "ASCII", "CPU", "CSS", "DNS",
+		"EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID",
+		"IP", "JSON", "QPS", "RAM", "RPC", "SLA",
+		"SMTP", "SQL", "SSH", "TCP", "TLS", "TTL",
+		"UDP", "UI", "GID", "UID", "UUID", "URI",
+		"URL", "UTF8", "VM", "XML", "XMPP", "XSRF",
+		"XSS", "SIP", "RTP", "AMQP", "DB", "TS",
+
+		// Media initialisms
+		"1080P", "2D", "3D", "4K", "8K", "AAC", "AC3",
+		"CDN", "DASH", "DRM", "DVR", "EAC3", "FPS", "GOP",
+		"H264", "H265", "HD", "HLS", "MJPEG", "MP2T", "MP3",
+		"MP4", "MPEG2", "MPEG4", "NTSC", "PCM", "RGB", "RGBA",
+		"RTMP", "RTP", "SCTE", "SCTE35", "SMPTE", "UPID", "UPIDS",
+		"VOD", "YUV420", "YUV422", "YUV444",
+
+		// Rotational Custom
+		"VASP", "AI", "LLM", "ULID",
+	}
+
+	suffixes = []string{
+		"D",    // E.g. 2D, 3D
+		"GB",   // E.g. 100GB
+		"K",    // E.g. 4K, 8K
+		"KB",   // E.g. 100KB
+		"KBPS", // E.g. 64kbps
+		"MB",   // E.g. 100MB
+		"MPBS", // E.g. 2500mbps
+		"P",    // E.g. 1080P
+		"TB",   // E.g. 100TB
+	}
+
+	// The lists above are maintained for ease of maintenance but are converted to
+	// sets for faster lookups at runtime.
+	initialismMap map[string]struct{}
+	suffixMap     map[string]struct{}
+)
+
+func init() {
+	initialismMap = make(map[string]struct{}, len(initialisms))
+	for _, initialism := range initialisms {
+		initialismMap[initialism] = struct{}{}
+	}
+
+	suffixMap = make(map[string]struct{}, len(suffixes))
+	for _, suffix := range suffixes {
+		suffixMap[suffix] = struct{}{}
+	}
+
+	suffixes = nil
+	initialisms = nil
+}
+
+//===========================================================================
+// Primary Case Functions
+//===========================================================================
+
+func Camel(s string, formatters ...Formatter) string {
+	if formatters == nil {
+		formatters = []Formatter{strings.ToLower}
+	}
+
+	// TODO: add support for other languages.
+	title := cases.Title(language.English)
+
+	f := append(formatters, title.String, Initialism)
+	return Join(Split(s), "", f...)
+}
+
+func LowerCamel(s string, formatters ...Formatter) string {
+	if formatters == nil {
+		formatters = []Formatter{strings.ToLower}
+	}
+
+	// TODO: add support for other languages.
+	title := cases.Title(language.English)
+	f := append(formatters, title.String, Initialism)
+	parts := Split(s)
+	runes := []rune(Join(parts, "", f...))
+
+	if len(parts) > 0 {
+		if _, ok := initialismMap[parts[0]]; !ok {
+			runes[0] = unicode.ToLower(runes[0])
+		} else {
+			return strings.Replace(string(runes), parts[0], strings.ToLower(parts[0]), 1)
+		}
+	}
+	return string(runes)
+}
+
+func Snake(s string, formatters ...Formatter) string {
+	if formatters == nil {
+		formatters = []Formatter{strings.ToLower}
+	}
+	return Join(Split(s), "_", formatters...)
+}
+
+func Kebab(s string, formatters ...Formatter) string {
+	if formatters == nil {
+		formatters = []Formatter{strings.ToLower}
+	}
+	return Join(Split(s), "-", formatters...)
+}
+
+func Constant(s string, formatters ...Formatter) string {
+	if formatters == nil {
+		formatters = []Formatter{strings.ToUpper}
+	}
+	return Join(Split(s), "_", formatters...)
+}
+
+func Title(s string, formatters ...Formatter) string {
+	if formatters == nil {
+		formatters = []Formatter{strings.ToLower}
+	}
+
+	// TODO: add support for other languages.
+	title := cases.Title(language.English)
+
+	f := append(formatters, title.String, Initialism)
+	return Join(Split(s), " ", f...)
+}
+
+//===========================================================================
+// Typecase Utilities
+//===========================================================================
+
+// Formatter is used to transform parts of a string to modify how a final case is rendered.
+type Formatter func(string) string
+
+// Identity formatter that returns its input unchanged.
+func Identity(s string) string {
+	return s
+}
+
+// Initialism checks if a string is an initialism and keeps it uppercaase.
+func Initialism(s string) string {
+	S := strings.ToUpper(s)
+	if _, ok := initialismMap[S]; ok {
+		return S
+	}
+	return s
+}
+
+// Split a value into parts, taking into account different casing styles.
+func Split(s string) (out []string) {
+	b := 0
+	state := stateNone
+
+splitter:
+	for i, c := range s {
+		// Regardless of state, spaces and punctuation break works.
+		// This also handles kabob and snake casing.
+		if unicode.IsSpace(c) || unicode.IsPunct(c) {
+			if i-b > 0 {
+				out = append(out, s[b:i])
+			}
+
+			b = i + 1
+			state = stateNone
+			continue splitter
+		}
+
+		switch {
+		case state != stateFirstUpper && state != stateUpper && unicode.IsUpper(c):
+			// Initial uppercase, might start a word, e.g. for CamelCase.
+			if b != i {
+				out = append(out, s[b:i])
+				b = i
+			}
+			state = stateFirstUpper
+		case state == stateFirstUpper && unicode.IsUpper(c):
+			// Group uppercase in case of initialisms or constant casing.
+			state = stateUpper
+		case state != stateSymbol && !unicode.IsLetter(c):
+			// Anything -> non-letter
+			if b != i {
+				out = append(out, s[b:i])
+				b = i
+			}
+			state = stateSymbol
+		case state != stateLower && unicode.IsLower(c):
+			// Multi-character uppercase -> lowercase and this is the last time the
+			// upercase is part of the string, e.g. JSONMessage.
+			if state == stateUpper {
+				if i > 0 && b != i-1 {
+					out = append(out, s[b:i-1])
+					b = i - 1
+				}
+			} else if state != stateFirstUpper {
+				// End of a non-uppercase or non-lowercase string. Ignore the first
+				// upper state as its part of the same word.
+				if i > 0 && b != i {
+					out = append(out, s[b:i])
+					b = i
+				}
+			}
+			state = stateLower
+		}
+	}
+
+	// Include whatever is at the end of the string.
+	if b < len(s) {
+		out = append(out, s[b:])
+	}
+
+	return out
+}
+
+// Join the parts of a string together with the separator applying formatters to each
+// part in order to get a specifically cased/formatted string. This method also removes
+// any empty parts from the final string.
+func Join(parts []string, sep string, formatters ...Formatter) string {
+	for i := 0; i < len(parts); i++ {
+	fmtloop:
+		for _, formatter := range formatters {
+			parts[i] = formatter(parts[i])
+			if parts[i] == "" {
+				break fmtloop
+			}
+		}
+
+		// If the part is empty, remove it from the slice.
+		if parts[i] == "" {
+			parts = append(parts[:i], parts[i+1:]...)
+			i--
+		}
+	}
+
+	return strings.Join(parts, sep)
+}

--- a/typecase/typecase_test.go
+++ b/typecase/typecase_test.go
@@ -1,0 +1,289 @@
+package typecase_test
+
+import (
+	"strings"
+	"testing"
+
+	"go.rtnl.ai/x/assert"
+	"go.rtnl.ai/x/typecase"
+)
+
+func TestTypecase(t *testing.T) {
+	tests := []string{
+		"",
+		"CamelCaseAlready",
+		"lowerCamelCaseAlready",
+		"snake_case_already",
+		"kebab-case-already",
+		"CONSTANT_CASE_ALREADY",
+		"Title Case Already",
+		"all lower already",
+		"ALL UPPER ALREADY",
+		"dot.separated.already",
+		"  too    many    spaces    in between  ",
+		"UserID",
+		"OriginatingVASP",
+		"HTTPS",
+		"aMix_of_CASE-formatStrings",
+		"remove_punctuation!@#%&*()?",
+		"fixture",
+		"d e f",
+		"7 8 9",
+		"uJSON456",
+		"global_ulid",
+		"mix888digits",
+		"weird---__.__---split",
+		"Emoji🚀🧜🐡Fun",
+		"ÜppigkeitKönigGlückFuß",
+		"JSONMessage",
+	}
+
+	t.Run("Camel", func(t *testing.T) {
+		expected := []string{
+			"",
+			"CamelCaseAlready",
+			"LowerCamelCaseAlready",
+			"SnakeCaseAlready",
+			"KebabCaseAlready",
+			"ConstantCaseAlready",
+			"TitleCaseAlready",
+			"AllLowerAlready",
+			"AllUpperAlready",
+			"DotSeparatedAlready",
+			"TooManySpacesInBetween",
+			"UserID",
+			"OriginatingVASP",
+			"HTTPS",
+			"AMixOfCaseFormatStrings",
+			"RemovePunctuation",
+			"Fixture",
+			"DEF",
+			"789",
+			"UJSON456",
+			"GlobalULID",
+			"Mix888Digits",
+			"WeirdSplit",
+			"Emoji🚀🧜🐡Fun",
+			"ÜppigkeitKönigGlückFuß",
+			"JSONMessage",
+		}
+
+		for i, test := range tests {
+			actual := typecase.Camel(test)
+			assert.Equal(t, expected[i], actual, "test case %d failed", i)
+		}
+	})
+
+	t.Run("LowerCamel", func(t *testing.T) {
+		expected := []string{
+			"",
+			"camelCaseAlready",
+			"lowerCamelCaseAlready",
+			"snakeCaseAlready",
+			"kebabCaseAlready",
+			"constantCaseAlready",
+			"titleCaseAlready",
+			"allLowerAlready",
+			"allUpperAlready",
+			"dotSeparatedAlready",
+			"tooManySpacesInBetween",
+			"userID",
+			"originatingVASP",
+			"https",
+			"aMixOfCaseFormatStrings",
+			"removePunctuation",
+			"fixture",
+			"dEF",
+			"789",
+			"uJSON456",
+			"globalULID",
+			"mix888Digits",
+			"weirdSplit",
+			"emoji🚀🧜🐡Fun",
+			"üppigkeitKönigGlückFuß",
+			"jsonMessage",
+		}
+
+		for i, test := range tests {
+			actual := typecase.LowerCamel(test)
+			assert.Equal(t, expected[i], actual, "test case %d failed", i)
+		}
+	})
+
+	t.Run("Snake", func(t *testing.T) {
+		expected := []string{
+			"",
+			"camel_case_already",
+			"lower_camel_case_already",
+			"snake_case_already",
+			"kebab_case_already",
+			"constant_case_already",
+			"title_case_already",
+			"all_lower_already",
+			"all_upper_already",
+			"dot_separated_already",
+			"too_many_spaces_in_between",
+			"user_id",
+			"originating_vasp",
+			"https",
+			"a_mix_of_case_format_strings",
+			"remove_punctuation",
+			"fixture",
+			"d_e_f",
+			"7_8_9",
+			"u_json_456",
+			"global_ulid",
+			"mix_888_digits",
+			"weird_split",
+			"emoji_🚀🧜🐡_fun",
+			"üppigkeit_könig_glück_fuß",
+			"json_message",
+		}
+
+		for i, test := range tests {
+			actual := typecase.Snake(test)
+			assert.Equal(t, expected[i], actual, "test case %d failed", i)
+		}
+	})
+
+	t.Run("Kebab", func(t *testing.T) {
+		expected := []string{
+			"",
+			"camel-case-already",
+			"lower-camel-case-already",
+			"snake-case-already",
+			"kebab-case-already",
+			"constant-case-already",
+			"title-case-already",
+			"all-lower-already",
+			"all-upper-already",
+			"dot-separated-already",
+			"too-many-spaces-in-between",
+			"user-id",
+			"originating-vasp",
+			"https",
+			"a-mix-of-case-format-strings",
+			"remove-punctuation",
+			"fixture",
+			"d-e-f",
+			"7-8-9",
+			"u-json-456",
+			"global-ulid",
+			"mix-888-digits",
+			"weird-split",
+			"emoji-🚀🧜🐡-fun",
+			"üppigkeit-könig-glück-fuß",
+			"json-message",
+		}
+
+		for i, test := range tests {
+			actual := typecase.Kebab(test)
+			assert.Equal(t, expected[i], actual, "test case %d failed", i)
+		}
+	})
+
+	t.Run("Constant", func(t *testing.T) {
+		expected := []string{
+			"",
+			"CAMEL_CASE_ALREADY",
+			"LOWER_CAMEL_CASE_ALREADY",
+			"SNAKE_CASE_ALREADY",
+			"KEBAB_CASE_ALREADY",
+			"CONSTANT_CASE_ALREADY",
+			"TITLE_CASE_ALREADY",
+			"ALL_LOWER_ALREADY",
+			"ALL_UPPER_ALREADY",
+			"DOT_SEPARATED_ALREADY",
+			"TOO_MANY_SPACES_IN_BETWEEN",
+			"USER_ID",
+			"ORIGINATING_VASP",
+			"HTTPS",
+			"A_MIX_OF_CASE_FORMAT_STRINGS",
+			"REMOVE_PUNCTUATION",
+			"FIXTURE",
+			"D_E_F",
+			"7_8_9",
+			"U_JSON_456",
+			"GLOBAL_ULID",
+			"MIX_888_DIGITS",
+			"WEIRD_SPLIT",
+			"EMOJI_🚀🧜🐡_FUN",
+			"ÜPPIGKEIT_KÖNIG_GLÜCK_FUß",
+			"JSON_MESSAGE",
+		}
+
+		for i, test := range tests {
+			actual := typecase.Constant(test)
+			assert.Equal(t, expected[i], actual, "test case %d failed", i)
+		}
+	})
+
+	t.Run("Title", func(t *testing.T) {
+		expected := []string{
+			"",
+			"Camel Case Already",
+			"Lower Camel Case Already",
+			"Snake Case Already",
+			"Kebab Case Already",
+			"Constant Case Already",
+			"Title Case Already",
+			"All Lower Already",
+			"All Upper Already",
+			"Dot Separated Already",
+			"Too Many Spaces In Between",
+			"User ID",
+			"Originating VASP",
+			"HTTPS",
+			"A Mix Of Case Format Strings",
+			"Remove Punctuation",
+			"Fixture",
+			"D E F",
+			"7 8 9",
+			"U JSON 456",
+			"Global ULID",
+			"Mix 888 Digits",
+			"Weird Split",
+			"Emoji 🚀🧜🐡 Fun",
+			"Üppigkeit König Glück Fuß",
+			"JSON Message",
+		}
+
+		for i, test := range tests {
+			actual := typecase.Title(test)
+			assert.Equal(t, expected[i], actual, "test case %d failed", i)
+		}
+	})
+}
+
+func TestJoin(t *testing.T) {
+	tests := []struct {
+		parts      []string
+		sep        string
+		formatters []typecase.Formatter
+		expected   string
+	}{
+		{
+			parts:      []string{"hello", "world"},
+			sep:        "_",
+			formatters: []typecase.Formatter{strings.ToUpper},
+			expected:   "HELLO_WORLD",
+		},
+		{
+			parts:      []string{"hello", "", "world", ""},
+			sep:        "_",
+			formatters: []typecase.Formatter{strings.ToUpper},
+			expected:   "HELLO_WORLD",
+		},
+		{
+			parts:      []string{"hello", "", "world", ""},
+			sep:        "-",
+			formatters: []typecase.Formatter{},
+			expected:   "hello-world",
+		},
+	}
+
+	for i, tc := range tests {
+		actual := typecase.Join(tc.parts, tc.sep, tc.formatters...)
+		assert.Equal(t, tc.expected, actual, "test case %d failed", i)
+	}
+}


### PR DESCRIPTION
### Scope of changes

Adds typecase library for template, code generation, and cross-language conversions.

Note that this does add a dependency on `golang.org/x` - and we should remove this as soon as the `x` package is merged into the golang standard library. 

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have added new test fixtures as needed to support added tests