### PR TITLE
Add verification token package `vero`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This is single repository that stores many, independent small subpackages. This 
 - [api](https://go.rtnl.ai/x/api): common utilities and responses for our JSON/REST APIs that our services run.
 - [dsn](https://go.rtnl.ai/x/dsn): parses data source names in order to connect to both server and embedded databases easily.
 - [semver](https://go.rtnl.ai/x/semver): allows parsing and comparison of semantic versioning numbers.
-- [typecase](https://go.rtnl.ai/x/semver): converst strings to different variable cases such as camel or snake case.
+- [typecase](https://go.rtnl.ai/x/semver): convert strings to different variable cases such as camel or snake case.
+- [vero](https://go.rtnl.ai/x/vero): create verification tokens against a record identifier, with an expiration.
 
 ## About
 

--- a/vero/README.md
+++ b/vero/README.md
@@ -1,0 +1,80 @@
+# Vero
+
+Vero allows you to create verification tokens against a record identifier (16 raw bytes) that also has an expiration time. An example use might be to send a user a link that includes the verification token, which when clicked could then allow them to securely change their password if it was forgotten.
+
+## Creating a token
+
+```go
+import "go.rtnl.ai/x/vero"
+
+// Create a token from 16 raw bytes that you wish to use as the identifier for this
+// verification. You must provide an expiration time in the future and a non-zero
+// byte slice.
+newRecordId := []bytes("1234567890abcdef") // in this example, we have a record ID to verify
+expiration := time.Now().Add(1 * time.Hour)
+token, err := vero.NewToken(newRecordId, expiration)
+
+// Sign the vero `token`, creating the `verification` token and the `signature`
+// token. You should keep the `signature` token a secret and only share the
+// `verification` token to verify against the `signature` later on. The `signature`
+// also has a copy of the `token` as `signature.Token`.
+if verification, signature, err := token.Sign(); err != nil {
+    panic(err) // something went wrong
+}
+
+// Be sure to store the `signature` for future verification. Best practice is to
+// associate the data you wish to verify with a record ID for the record in the
+// persistent storage where you'll store the `signature` and `expiration`. The
+// record ID for this record should be the same as the vero token's record ID,
+// otherwise there isn't any reference for you to load the `signature` later on
+// when you recieve the `verification` back.
+newUserIdVerification := []struct{
+    ID: newRecordId,        // the vero token's record ID
+    Signature: signature,   // the signature to verify against later (this is a secret)
+    Expiration: expiration, // the expiration
+    UserID: "userid123",    // we associate a user's ID with this vero token (you could do other things)
+}
+storeVeroInDatabase(newUserIdVerification)
+
+// You can then send or store the `verification` token, which can be used later to
+// verify against the `signature` token.
+sendVerificationToken(verification)
+```
+
+## Verifying a token
+
+```go
+import "go.rtnl.ai/x/vero"
+
+// Initially the token is recieved as a string.
+verificationTokenString = "MTIzNDU2Nzg5MGFiY2RlZvRoC07KOs375xDclKlFe2gKk3TUcxj7-ID9TlccbGtE3dAEFjzOE9o2B9e-y_lNqkTVJfEPm3n8Kt-9gPQbU-E"
+
+// Parse the verification token string into a VerificationToken.
+var verification *vero.VerificationToken
+if verification, err = vero.ParseVerification(verificationTokenString); err != nil {
+    panic(err) // something went wrong
+}
+
+// Load your signature token that was saved when you created the vero token.
+veroRecord := loadVeroFromDatabase(verification.RecordID) // we stored it under this record ID, as is the best practice
+
+// Check that the verification token that was recieved is secure and valid.
+ if secure, err := veroRecord.Signature.Verify(verification); err != nil || !secure {
+    if !secure{
+        panic("insecure verification token!") // a very bad situation
+    }
+    if err != nil{
+        panic(err) // something went wrong
+    }
+ }
+
+ // Check that the token has not expired.
+ if veroRecord.Signature.Token.IsExpired() {
+    panic("The token is expired")
+ }
+
+ // The token is verified at this point, so you can do the stuff you wanted to verify
+ // through the token first, such as changing the user's password for a password reset
+ // email
+ doSecureStuff()
+```

--- a/vero/errors.go
+++ b/vero/errors.go
@@ -1,0 +1,15 @@
+package vero
+
+import "errors"
+
+var (
+	ErrDecode                 = errors.New("vero: could not decode token")
+	ErrTokenSize              = errors.New("vero: invalid size for token")
+	ErrRecordIDSize           = errors.New("vero: invalid size for record id")
+	ErrInvalidExpiration      = errors.New("vero: must provide an expiration time in the future")
+	ErrInvalidTokenRecordID   = errors.New("vero: invalid verification token: no record id")
+	ErrInvalidTokenExpiration = errors.New("vero: invalid verification token: no expiration timestamp")
+	ErrInvalidTokenNonce      = errors.New("vero: invalid verification token: incorrect nonce")
+	ErrInvalidTokenSignature  = errors.New("vero: invalid verification token: incorrect hmac signature")
+	ErrUnexpectedType         = errors.New("vero: could not scan non-bytes type")
+)

--- a/vero/verify.go
+++ b/vero/verify.go
@@ -1,0 +1,338 @@
+package vero
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql/driver"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	nonceLength        = 64
+	keyLength          = 64
+	hmacLength         = 32
+	recordIdLength     = 16 // 16 bytes fits a ULID
+	minTokenLength     = recordIdLength + nonceLength + 1
+	maxTokenLength     = recordIdLength + nonceLength + binary.MaxVarintLen64
+	minSignTokenLength = minTokenLength + hmacLength
+	maxSignTokenLength = maxTokenLength + hmacLength
+	verifyTokenLength  = recordIdLength + keyLength
+)
+
+// A Token is a data representation of the information needed to create a secure
+// record verification token for use in cases such as sending Sunrise email or
+// password reset links. Tokens can be used to generate SignedTokens and
+// SignedTokens can be used to send a secure verification token and to verify
+// that tokens belong to the specified user.
+type Token struct {
+	RecordID   []byte    // ID of the record in the database for verification
+	Expiration time.Time // Expiration date of the token (not after)
+	nonce      []byte    // Random nonce for cryptographic security
+}
+
+// A signed token contains a signature that can be stored in the local database in
+// order to verify an incoming verification token from a client.
+type SignedToken struct {
+	Token
+	signature []byte // The HMAC signature computed from the Token data (read-only)
+}
+
+// A verification token is sent to the client and contains the information needed to
+// lookup a signed token in the database and to verify that the message is authentic.
+type VerificationToken []byte
+
+//===========================================================================
+// Token Methods
+//===========================================================================
+
+// Create a new token with the specified record ID and expiration timestamp. The
+// `recordId` must be 16 bytes in length and the `expiration` must be in the future.
+func NewToken(recordID []byte, expiration time.Time) (token *Token, err error) {
+	if expiration.IsZero() || expiration.Before(time.Now()) {
+		return nil, ErrInvalidExpiration
+	}
+
+	if recordIdLength != len(recordID) {
+		return nil, ErrRecordIDSize
+	}
+
+	token = &Token{
+		RecordID:   recordID,
+		Expiration: expiration,
+		nonce:      make([]byte, nonceLength),
+	}
+
+	if _, err := rand.Read(token.nonce); err != nil {
+		panic(fmt.Errorf("no crypto random generator available: %w", err))
+	}
+
+	return token, nil
+}
+
+// Sign a token creating a verification token that should be sent as a string to the
+// counterparty and a signed token that should be stored in the database.
+func (t *Token) Sign() (token VerificationToken, signature *SignedToken, err error) {
+	// Generate nonce if the token was instantiated without New
+	if t.nonce == nil {
+		t.nonce = make([]byte, nonceLength)
+		if _, err := rand.Read(t.nonce); err != nil {
+			panic(fmt.Errorf("no crypto random generator available: %w", err))
+		}
+	}
+
+	// Create a random secret key for signing
+	secret := make([]byte, keyLength)
+	if _, err := rand.Read(secret); err != nil {
+		panic(fmt.Errorf("no crypto random generator available: %w", err))
+	}
+
+	// Marshal the token for signing
+	var data []byte
+	if data, err = t.MarshalBinary(); err != nil {
+		return nil, nil, err
+	}
+
+	// Create HMAC signature for the token
+	mac := hmac.New(sha256.New, secret)
+	if _, err = mac.Write(data); err != nil {
+		return nil, nil, err
+	}
+
+	// Get the HMAC signature and append it to the verification data
+	// NOTE: this must happen after HMAC signing!
+	signature = &SignedToken{
+		Token:     *t,
+		signature: mac.Sum(nil),
+	}
+
+	// Create the verification token
+	token = make(VerificationToken, verifyTokenLength)
+	copy(token[0:16], t.RecordID[:])
+	copy(token[16:], secret)
+
+	return token, signature, nil
+}
+
+func (t *Token) IsExpired() bool {
+	if t.Expiration.IsZero() {
+		return true
+	}
+	return t.Expiration.Before(time.Now())
+}
+
+func (t *Token) MarshalBinary() ([]byte, error) {
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, maxTokenLength)
+	copy(data[:16], t.RecordID[:])
+
+	i := binary.PutVarint(data[16:], t.Expiration.UnixNano())
+	l := 16 + i
+	copy(data[l:], t.nonce)
+
+	l = l + nonceLength
+	return data[:l], nil
+}
+
+func (t *Token) UnmarshalBinary(data []byte) error {
+	if _, err := t.readFrom(data); err != nil {
+		return err
+	}
+	return t.Validate()
+}
+
+func (t *Token) readFrom(data []byte) (int, error) {
+	if len(data) > maxTokenLength || len(data) < minTokenLength {
+		return 0, ErrTokenSize
+	}
+
+	// Parse record ID
+	t.RecordID = []byte(data[:16])
+
+	// Parse expiration time
+	exp, i := binary.Varint(data[16 : 16+binary.MaxVarintLen64])
+	if i <= 0 {
+		return 16, ErrDecode
+	}
+	t.Expiration = time.Unix(0, exp)
+
+	// Read the nonce data
+	l := 16 + i
+	if len(data[l:]) < nonceLength {
+		return l, ErrInvalidTokenNonce
+	}
+	t.nonce = data[l : l+nonceLength]
+
+	// Validate the binary data
+	return l + nonceLength, nil
+}
+
+func (t *Token) Validate() (err error) {
+	if len(t.RecordID) != recordIdLength {
+		err = errors.Join(err, ErrRecordIDSize)
+	}
+
+	empty := make([]byte, recordIdLength)
+	if bytes.Equal(t.RecordID, empty) {
+		err = errors.Join(err, ErrInvalidTokenRecordID)
+	}
+
+	if t.Expiration.IsZero() {
+		err = errors.Join(err, ErrInvalidTokenExpiration)
+	}
+
+	if len(t.nonce) != nonceLength {
+		err = errors.Join(err, ErrInvalidTokenNonce)
+	}
+
+	return err
+}
+
+func (t *Token) Equal(o *Token) bool {
+	return bytes.Equal(t.RecordID[:], o.RecordID[:]) &&
+		t.Expiration.Equal(o.Expiration) &&
+		bytes.Equal(t.nonce, o.nonce)
+}
+
+//===========================================================================
+// SignedToken Methods
+//===========================================================================
+
+// Verify that a signed token belongs with the associated verification token.
+func (t *SignedToken) Verify(token VerificationToken) (secure bool, err error) {
+	if len(token) != verifyTokenLength {
+		return false, ErrTokenSize
+	}
+
+	// Compute the hash of the current token for verification
+	var data []byte
+	if data, err = t.Token.MarshalBinary(); err != nil {
+		return false, err
+	}
+
+	// Generate the HMAC signature of the current token
+	mac := hmac.New(sha256.New, token.Secret())
+	if _, err := mac.Write(data); err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(t.signature, mac.Sum(nil)), nil
+}
+
+// Retrieve the signature from the signed token.
+func (t *SignedToken) Signature() []byte {
+	return t.signature
+}
+
+// Scan the signed token from a database query.
+func (t *SignedToken) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	data, ok := value.([]byte)
+	if !ok {
+		return ErrUnexpectedType
+	}
+
+	return t.UnmarshalBinary(data)
+}
+
+// Produce a database value from the signed token for inserts/updates to database.
+func (t *SignedToken) Value() (_ driver.Value, err error) {
+	if t == nil {
+		return nil, nil
+	}
+
+	var data []byte
+	if data, err = t.MarshalBinary(); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (t *SignedToken) MarshalBinary() (out []byte, err error) {
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+
+	var token []byte
+	if token, err = t.Token.MarshalBinary(); err != nil {
+		return nil, err
+	}
+
+	out = make([]byte, maxSignTokenLength)
+	copy(out[:len(token)], token)
+	copy(out[len(token):], t.signature)
+
+	return out[:len(token)+len(t.signature)], nil
+}
+
+func (t *SignedToken) UnmarshalBinary(data []byte) (err error) {
+	if len(data) > maxSignTokenLength || len(data) < minSignTokenLength {
+		return ErrTokenSize
+	}
+
+	// Parse Token
+	var n int
+	if n, err = t.Token.readFrom(data[:maxTokenLength]); err != nil {
+		return err
+	}
+
+	// Extract the signature as the unread part of the data
+	t.signature = data[n:]
+
+	// Validate the binary data
+	return t.Validate()
+}
+
+func (t *SignedToken) Validate() (err error) {
+	err = t.Token.Validate()
+
+	if len(t.signature) != hmacLength {
+		err = errors.Join(err, ErrInvalidTokenSignature)
+	}
+
+	return err
+}
+
+func (t *SignedToken) Equal(o *SignedToken) bool {
+	return t.Token.Equal(&o.Token) && bytes.Equal(t.signature, o.signature)
+}
+
+//===========================================================================
+// VerificationToken Methods
+//===========================================================================
+
+func ParseVerification(tks string) (_ VerificationToken, err error) {
+	var token []byte
+	if token, err = base64.RawURLEncoding.DecodeString(tks); err != nil {
+		return nil, err
+	}
+
+	if len(token) != verifyTokenLength {
+		return nil, ErrTokenSize
+	}
+
+	return VerificationToken(token), nil
+}
+
+func (v VerificationToken) RecordID() []byte {
+	return []byte(v[:16])
+}
+
+func (v VerificationToken) Secret() []byte {
+	return v[16:]
+}
+
+func (v VerificationToken) String() string {
+	return base64.RawURLEncoding.EncodeToString(v)
+}

--- a/vero/verify_test.go
+++ b/vero/verify_test.go
@@ -1,0 +1,428 @@
+package vero_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"go.rtnl.ai/x/assert"
+	"go.rtnl.ai/x/vero"
+)
+
+func TestVerification(t *testing.T) {
+	// Generate verification token and signature
+	token, err := vero.NewToken(makeRecordId(), time.Now().Add(1*time.Hour))
+	assert.Nil(t, err, "could not create token")
+	verify, signature, err := token.Sign()
+	assert.Nil(t, err, "could not sign token")
+
+	// Create tokens string to send to user; assume that the signature is saved to db and loaded again
+	tks := verify.String()
+
+	// Pretend to save the signature to the database by marshaling it
+	dbd, err := signature.MarshalBinary()
+	assert.Nil(t, err, "could not marshal signature")
+
+	// Parse the incoming token from the user
+	parsed_token, err := vero.ParseVerification(tks)
+	assert.Nil(t, err, "could not parse verification token")
+
+	// Pretend to load the signature from the database by unmarshaling it
+	signature = &vero.SignedToken{}
+	err = signature.UnmarshalBinary(dbd)
+	assert.Nil(t, err, "could not unmarshal signature")
+
+	// Complete the workflow by verifying that everything is correct and secure
+	secure, err := signature.Verify(parsed_token)
+	assert.Nil(t, err, "could not verify token")
+	assert.True(t, secure, "verification returned false")
+}
+
+func TestNewToken(t *testing.T) {
+	t.Run("RequiresExpiration", func(t *testing.T) {
+		token, err := vero.NewToken(makeRecordId(), time.Time{})
+		assert.ErrorIs(t, err, vero.ErrInvalidExpiration, "no error for zero value expiration")
+		assert.Nil(t, token, "token should be nil")
+	})
+
+	t.Run("NonceGeneration", func(t *testing.T) {
+		token, err := vero.NewToken(makeRecordId(), time.Now().Add(1*time.Minute))
+		assert.Nil(t, err, "could not create token")
+		data, err := token.MarshalBinary()
+		assert.Nil(t, err, "could not marshal binary")
+
+		// Expects nonce length to be 64!
+		assert.NotEqual(t, bytes.Repeat([]byte{0x0}, 64), data[len(data)-64:], "zero-valued nonce!")
+	})
+
+	t.Run("Randomness", func(t *testing.T) {
+		recordID := makeRecordId()
+		expiration := time.Now().Add(1 * time.Hour)
+
+		// Generate 16 tokens with the same recordID and expiration timestamp
+		tokens := make([]*vero.Token, 0, 16)
+		for i := 0; i < 16; i++ {
+			token, err := vero.NewToken(recordID, expiration)
+			assert.Nil(t, err, "could not create token")
+			tokens = append(tokens, token)
+		}
+
+		// Ensure that all marshaled tokens are different (because of the nonce)
+		for i, alpha := range tokens {
+			for j, bravo := range tokens {
+				if i == j {
+					// Don't compare the same token to itself
+					continue
+				}
+
+				da, err := alpha.MarshalBinary()
+				assert.Nil(t, err, "could not marshal token %d", i)
+
+				db, err := bravo.MarshalBinary()
+				assert.Nil(t, err, "could not marshal token %d", j)
+
+				assert.False(t, bytes.Equal(da, db), "tokens %d and %d were identical!", i, j)
+			}
+		}
+
+	})
+}
+
+func TestTokenExpiration(t *testing.T) {
+	t.Run("Happy", func(t *testing.T) {
+		token, err := vero.NewToken(makeRecordId(), time.Now().Add(1*time.Minute))
+		assert.Nil(t, err, "could not create token")
+		assert.False(t, token.IsExpired(), "token should not be expired")
+	})
+
+	t.Run("ExpirationInPast", func(t *testing.T) {
+		token, err := vero.NewToken(makeRecordId(), time.Now().Add(-1*time.Minute))
+		assert.ErrorIs(t, err, vero.ErrInvalidExpiration, "expiration in past should return an error")
+		assert.Nil(t, token, "token should be nil")
+	})
+
+	t.Run("NoExpiration", func(t *testing.T) {
+		token, err := vero.NewToken(makeRecordId(), time.Time{})
+		assert.ErrorIs(t, err, vero.ErrInvalidExpiration, "lack of expiration should return an error")
+		assert.Nil(t, token, "token should be nil")
+	})
+}
+
+func TestTokenSign(t *testing.T) {
+	t.Run("Happy", func(t *testing.T) {
+		token, err := vero.NewToken(makeRecordId(), time.Now().Add(1*time.Minute))
+		assert.Nil(t, err, "could not create token")
+		verification, signature, err := token.Sign()
+		assert.Nil(t, err, "could not sign token")
+		assert.Len(t, verification, 16+64, "unexpected length of verification token (16 bytes + 64 byte secret)")
+		assert.Len(t, signature.Signature(), 32, "unexpected length of hmac signature (32 bytes for sha256)")
+	})
+
+	t.Run("WithoutNonce", func(t *testing.T) {
+		token := &vero.Token{RecordID: makeRecordId(), Expiration: time.Now().Add(1 * time.Minute)}
+		verification, signature, err := token.Sign()
+		assert.Nil(t, err, "could not sign token")
+		assert.Len(t, verification, 16+64, "unexpected length of verification token (16 bytes + 64 byte secret)")
+		assert.Len(t, signature.Signature(), 32, "unexpected length of hmac signature (32 bytes for sha256)")
+	})
+
+	t.Run("VerificationToken", func(t *testing.T) {
+		recordID := makeRecordId()
+		token, err := vero.NewToken(recordID, time.Now().Add(1*time.Minute))
+		assert.Nil(t, err, "could not create token")
+		verify, _, err := token.Sign()
+		assert.Nil(t, err, "could not sign token")
+		assert.Equal(t, recordID, verify.RecordID(), "expected record ID to match")
+		assert.Len(t, verify.Secret(), 64, "expected secret to be 64 bytes long")
+	})
+
+	t.Run("Sad", func(t *testing.T) {
+		testCases := []*vero.Token{
+			{},                         // empty
+			{RecordID: makeRecordId()}, // no expiration
+			{RecordID: make([]byte, 16), Expiration: time.Now().Add(1 * time.Minute)}, // zeroed recordID
+		}
+
+		for i, token := range testCases {
+			verify, signature, err := token.Sign()
+			assert.NotNil(t, err, "expected an error on test case %d", i)
+			assert.Nil(t, verify, "expected nil verification on test case %d", i)
+			assert.Nil(t, signature, "expected nil signed token on test case %d", i)
+		}
+	})
+
+	t.Run("SecretRandomness", func(t *testing.T) {
+		// Create a token with constant nonce, record id, and expiration
+		token, err := vero.NewToken(makeRecordId(), time.Now().Add(1*time.Hour))
+		assert.Nil(t, err, "could not create token")
+
+		// Create 16 verification tokens from the same token
+
+		tokens := make([]vero.VerificationToken, 0, 16)
+		signatures := make([]*vero.SignedToken, 0, 16)
+		for i := 0; i < 16; i++ {
+			verify, signed, err := token.Sign()
+			assert.Nil(t, err, "could not sign token")
+
+			tokens = append(tokens, verify)
+			signatures = append(signatures, signed)
+		}
+
+		for i, alpha := range tokens {
+			for j, bravo := range tokens {
+				if i == j {
+					// Don't compare the same token
+					continue
+				}
+
+				// No two verification tokens and signatures should be the same
+				assert.False(t, bytes.Equal(alpha, bravo), "verification token %d is equal to token %d", i, j)
+				assert.False(t, bytes.Equal(signatures[i].Signature(), signatures[j].Signature()), "signature %d is equal to signature %d", i, j)
+			}
+		}
+
+	})
+
+}
+
+func TestTokenBinary(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		testCases := []struct {
+			recordID   []byte
+			expiration time.Time
+		}{
+			{makeRecordId(), time.Now().Add(1 * time.Minute)},
+			{makeRecordId(), time.Now().Add(312391 * time.Hour)},
+		}
+
+		for i, tc := range testCases {
+			token, err := vero.NewToken(tc.recordID, tc.expiration)
+			assert.Nil(t, err, "could not create token %d", i)
+
+			data, err := token.MarshalBinary()
+			assert.NotNil(t, data, "test case %d returned nil data", i)
+			assert.Nil(t, err, "test case %d errored on marshal", i)
+
+			cmpt := &vero.Token{}
+			err = cmpt.UnmarshalBinary(data)
+			assert.Nil(t, err, "test case %d errored on unmarshal", i)
+
+			assert.True(t, token.Equal(cmpt), "deserialization mismatch for test case %d", i)
+		}
+	})
+
+	t.Run("BadMarshal", func(t *testing.T) {
+		testCases := []struct {
+			token *vero.Token
+			err   error
+		}{
+			{
+				&vero.Token{RecordID: make([]byte, 16), Expiration: time.Now().Add(1 * time.Minute)},
+				vero.ErrInvalidTokenRecordID,
+			},
+			{
+				&vero.Token{RecordID: makeRecordId(), Expiration: time.Time{}},
+				vero.ErrInvalidTokenExpiration,
+			},
+		}
+
+		for i, tc := range testCases {
+			data, err := tc.token.MarshalBinary()
+			assert.Nil(t, data, "test case %d returned non-nil data", i)
+			assert.ErrorIs(t, err, tc.err, "test case %d returned the wrong error", i)
+		}
+	})
+
+	t.Run("BadUnmarshal", func(t *testing.T) {
+		testCases := []struct {
+			data []byte
+			err  error
+		}{
+			{
+				nil,
+				vero.ErrTokenSize,
+			},
+			{
+				[]byte{},
+				vero.ErrTokenSize,
+			},
+			{
+				[]byte{0x1, 0x2, 0x3, 0x4, 0xf, 0xfe},
+				vero.ErrTokenSize,
+			},
+			{
+				bytes.Repeat([]byte{0x1, 0x2, 0x3, 0x4, 0xf, 0xfe}, 64),
+				vero.ErrTokenSize,
+			},
+			{
+				[]byte{
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+				},
+				vero.ErrDecode,
+			},
+			{
+				[]byte{
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0xff, 0x00,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d,
+				},
+				vero.ErrInvalidTokenNonce,
+			},
+		}
+
+		for i, tc := range testCases {
+			token := &vero.Token{}
+			err := token.UnmarshalBinary(tc.data)
+			assert.ErrorIs(t, err, tc.err, "test case %d returned the wrong error", i)
+		}
+	})
+}
+
+func TestSignedTokenBinary(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		testCases := []struct {
+			recordID   []byte
+			expiration time.Time
+		}{
+			{
+				makeRecordId(),
+				time.Now().Add(1 * time.Minute),
+			},
+			{
+				makeRecordId(),
+				time.Now().Add(312391 * time.Hour),
+			},
+		}
+
+		for i, tc := range testCases {
+			token, err := vero.NewToken(tc.recordID, tc.expiration)
+			assert.Nil(t, err, "could not create token %d", i)
+
+			_, signed, err := token.Sign()
+			assert.Nil(t, err, "could not sign token %d", i)
+
+			data, err := signed.MarshalBinary()
+			assert.NotNil(t, data, "test case %d returned nil data", i)
+			assert.Nil(t, err, "test case %d errored on marshal", i)
+
+			cmpt := &vero.SignedToken{}
+			err = cmpt.UnmarshalBinary(data)
+			assert.Nil(t, err, "test case %d errored on unmarshal", i)
+
+			assert.True(t, signed.Equal(cmpt), "deserialization mismatch for test case %d", i)
+		}
+	})
+
+	t.Run("BadMarshal", func(t *testing.T) {
+		testCases := []struct {
+			token *vero.SignedToken
+			err   error
+		}{
+			{
+				&vero.SignedToken{},
+				vero.ErrInvalidTokenSignature,
+			},
+		}
+
+		for i, tc := range testCases {
+			data, err := tc.token.MarshalBinary()
+			assert.Nil(t, data, "test case %d returned non-nil data", i)
+			assert.ErrorIs(t, err, tc.err, "test case %d returned the wrong error", i)
+		}
+	})
+
+	t.Run("BadUnmarshal", func(t *testing.T) {
+		testCases := []struct {
+			data []byte
+			err  error
+		}{
+			{
+				nil,
+				vero.ErrTokenSize,
+			},
+			{
+				[]byte{},
+				vero.ErrTokenSize,
+			},
+			{
+				[]byte{0x1, 0x2, 0x3, 0x4, 0xf, 0xfe},
+				vero.ErrTokenSize,
+			},
+			{
+				bytes.Repeat([]byte{0x1, 0x2, 0x3, 0x4, 0xf, 0xfe}, 64),
+				vero.ErrTokenSize,
+			},
+			{
+				[]byte{
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0xff, 0x00,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+					0x22, 0x1, 0x33, 0x41, 0xd3, 0x7a, 0x12, 0xc2, 0xab, 0x41, 0x0, 0xfc, 0xe1, 0x7b, 0x7d, 0x15,
+				},
+				vero.ErrInvalidTokenSignature,
+			},
+		}
+
+		for i, tc := range testCases {
+			token := &vero.SignedToken{}
+			err := token.UnmarshalBinary(tc.data)
+			assert.ErrorIs(t, err, tc.err, "test case %d returned the wrong error", i)
+		}
+	})
+}
+
+func TestVerificationToken(t *testing.T) {
+	t.Run("Static", func(t *testing.T) {
+		tks := "MTIzNDU2Nzg5MGFiY2RlZvRoC07KOs375xDclKlFe2gKk3TUcxj7-ID9TlccbGtE3dAEFjzOE9o2B9e-y_lNqkTVJfEPm3n8Kt-9gPQbU-E"
+		token, err := vero.ParseVerification(tks)
+		assert.Nil(t, err, "could not parse good verification token")
+		assert.Equal(t, token.RecordID(), []byte("1234567890abcdef"), "unexpected record id")
+
+		secret := []byte{
+			0xF4, 0x68, 0x0B, 0x4E, 0xCA, 0x3A, 0xCD, 0xFB, 0xE7, 0x10, 0xDC, 0x94, 0xA9, 0x45, 0x7B, 0x68,
+			0x0A, 0x93, 0x74, 0xD4, 0x73, 0x18, 0xFB, 0xF8, 0x80, 0xFD, 0x4E, 0x57, 0x1C, 0x6C, 0x6B, 0x44,
+			0xDD, 0xD0, 0x04, 0x16, 0x3C, 0xCE, 0x13, 0xDA, 0x36, 0x07, 0xD7, 0xBE, 0xCB, 0xF9, 0x4D, 0xAA,
+			0x44, 0xD5, 0x25, 0xF1, 0x0F, 0x9B, 0x79, 0xFC, 0x2A, 0xDF, 0xBD, 0x80, 0xF4, 0x1B, 0x53, 0xE1,
+		}
+
+		assert.Equal(t, secret, token.Secret(), "unexpected secret")
+	})
+
+	t.Run("TooShort", func(t *testing.T) {
+		tks := "k0ZmbMJcQeyFtAtZ0_2EXMHwJ1ufcB4831ozVeHzAcVpyKybKzelG0l9qbJ4K5IUjaGSx5EdJ_"
+		token, err := vero.ParseVerification(tks)
+		assert.ErrorIs(t, err, vero.ErrTokenSize, "expected size parsing error")
+		assert.Nil(t, token, "expected nil token returned")
+	})
+
+	t.Run("BadDecode", func(t *testing.T) {
+		// '}' at char 19
+		tks := "k0ZmbMJcQeyFtAtZ0_2}XMHwJ1ufcB4831ozVeHzAcVpyKybKzelG0l9qbJ4K5IUjaGSx5EdJ_"
+		token, err := vero.ParseVerification(tks)
+		assert.Equal(t, err.Error(), "illegal base64 data at input byte 19", "expected base64 parsing error")
+		assert.Nil(t, token, "expected nil token returned")
+	})
+}
+
+// Helpers
+
+func makeRecordId() (out []byte) {
+	out = make([]byte, 16)
+	if _, err := rand.Read(out); err != nil {
+		panic(err)
+	}
+	return out
+}

--- a/vero/vero.go
+++ b/vero/vero.go
@@ -1,0 +1,1 @@
+package vero


### PR DESCRIPTION
### Scope of changes

Pulled from Envoy's `verification` package and renamed `vero`.

Other modifications from Envoy's `verification` package:

- takes 16 raw bytes as a byte slice for the RecordID
- NewToken() returns `token, err` now for a better library dev experience (less panics)
- modified tests to remove external imports (now uses `rotational/x/assert`) and to use bytes instead of ULIDs
- added a README

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?