### PR TITLE
HTTPCC: Cache-Control Headers for HTTP

### DIFF
--- a/httpcc/README.md
+++ b/httpcc/README.md
@@ -1,0 +1,36 @@
+# Cache Control (httpcc)
+
+Implements [RFC 7234](http://tools.ietf.org/html/rfc7234) Hypertext Transfer Protocol (HTTP/1.1): Caching. It does this by parsing the Cache-Control and other headers, providing cache directives about requests and responses. Note `httpcc` does not implement an actual cache backend, just the directives to influence cache behavior.
+
+## Parsing Cache Control Headers
+
+The [cache control directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) are specified in the `Cache-Control` headers of both HTTP requests and responses (and the available directives are slightly different for each).
+
+To parse request directives:
+
+```go
+directives, err := httpcc.Request(req)
+```
+
+And to parse response directives:
+
+```go
+directives, err := httpcc.Response(rep)
+```
+
+You can also pass in a cache control string using `req.Headers.Get("Cache-Control")` to
+parse that header by itself, though other headers will not be available in the response.
+
+## Other Cache Control Headers
+
+This package also supports other headers that may influence caching such as the following response headers:
+
+- `Expires`
+- `Last-Modified`
+- `ETag`
+
+And the following request headers:
+
+- `If-None-Match`
+- `If-Modified-Since`
+- `If-Unmodified-Since`

--- a/httpcc/directives.go
+++ b/httpcc/directives.go
@@ -1,0 +1,281 @@
+package httpcc
+
+import "time"
+
+// Directive includes cache directives for both requests and responses.
+type Directive struct {
+	maxAge       *uint64
+	noCache      bool
+	noStore      bool
+	noTransform  bool
+	staleIfError *uint64
+	extensions   map[string]string
+}
+
+// Directives that are only part of an HTTP request. These directives are usually
+// parsed on the server side and constructed by a client to send to the server.
+type RequestDirective struct {
+	Directive
+	ifNoneMatch       *string
+	ifUnmodifiedSince *time.Time
+	ifModifiedSince   *time.Time
+	maxStale          *uint64
+	minFresh          *uint64
+	onlyIfCached      bool
+}
+
+// Directives that a server sends back to a client in an HTTP response. These directives
+// are used to control caching behavior on the client side or in intermediate caches.
+type ResponseDirective struct {
+	Directive
+	expires              *time.Time
+	lastModified         *time.Time
+	etag                 *string
+	sMaxAge              *uint64
+	mustRevalidate       bool
+	proxyRevalidate      bool
+	mustUnderstand       bool
+	private              bool
+	public               bool
+	immutable            bool
+	staleWhileRevalidate *uint64
+}
+
+//===========================================================================
+// Directive Methods
+//===========================================================================
+
+// The max-age=N response directive indicates that the response remains fresh until
+// N seconds after the response is generated. Stored HTTP responses have two states:
+// fresh and stale. The fresh state usually indicates that the response is still valid
+// and can be reused, while the stale state means that the cached response has already
+// expired. The criterion for determining when a response is fresh and when it is stale
+// is age. In HTTP, age is the time elapsed since the response was generated.
+//
+// For requests, The max-age=N request directive indicates that the client allows a
+// stored response that is generated on the origin server within N seconds — where N
+// may be any non-negative integer (including 0).
+func (d *Directive) MaxAge() (uint64, bool) {
+	if v := d.maxAge; v != nil {
+		return *v, true
+	}
+	return 0, false
+}
+
+// The no-cache response directive indicates that the response can be stored in caches,
+// but the response must be validated with the origin server before each reuse, even
+// when the cache is disconnected from the origin server.
+//
+// For requests, the no-cache request directive asks caches to validate the response
+// with the origin server before reuse.
+func (d *Directive) NoCache() bool {
+	return d.noCache
+}
+
+// The no-store response directive indicates that any caches of any kind (private or
+// shared) should not store this response.
+//
+// For requests, the no-store request directive allows a client to request that caches
+// refrain from storing the request and corresponding response — even if the origin
+// server's response could be stored.
+func (d *Directive) NoStore() bool {
+	return d.noStore
+}
+
+// Some intermediaries transform content for various reasons. For example, some convert
+// images to reduce transfer size. In some cases, this is undesirable for the content
+// provider. no-transform indicates that any intermediary (regardless of whether it
+// implements a cache) shouldn't transform the response contents.
+func (d *Directive) NoTransform() bool {
+	return d.noTransform
+}
+
+// The stale-if-error request directive indicates that the browser is interested in
+// receiving stale content on error from any intermediate server for a particular
+// origin. This is not supported by any browser.
+func (d *Directive) StaleIfError() (uint64, bool) {
+	if v := d.staleIfError; v != nil {
+		return *v, true
+	}
+	return 0, false
+}
+
+// Extensions are used to collect additional information stored in the directive that
+// are not part of the standard HTTP cache directives. These extensions can be used
+// to provide additional metadata or custom behavior for caching.
+func (d *Directive) Extensions() map[string]string {
+	return d.extensions
+}
+
+// Get a specific extension value by its key. If the key does not exist, it returns an
+// empty string. Note that if a boolean value is stored as an extension, it will return
+// the name of the extension as a string if it has been set.
+func (d *Directive) Extension(s string) string {
+	return d.extensions[s]
+}
+
+//===========================================================================
+// Request Directive Methods
+//===========================================================================
+
+// The HTTP If-None-Match request header makes a request conditional. The server returns
+// the requested resource in GET and HEAD methods with a 200 status, only if it doesn't
+// have an ETag matching the ones in the If-None-Match header.
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-None-Match
+func (d *RequestDirective) IfNoneMatch() (string, bool) {
+	if v := d.ifNoneMatch; v != nil {
+		return *v, true
+	}
+	return "", false
+}
+
+// The HTTP If-Unmodified-Since request header makes the request for the resource
+// conditional. The server will send the requested resource (or accept it in the case
+// of a POST or another non-safe method) only if the resource on the server has not
+// been modified after the date in the request header.
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Unmodified-Since
+func (d *RequestDirective) IfUnmodifiedSince() (time.Time, bool) {
+	if v := d.ifUnmodifiedSince; v != nil {
+		return *v, true
+	}
+	return time.Time{}, false
+}
+
+// The HTTP If-Modified-Since request header makes a request conditional. The server
+// sends back the requested resource, with a 200 status, only if it has been modified
+// after the date in the If-Modified-Since header. If the resource has not been modified
+// since, the response is a 304 without any body, and the Last-Modified response header
+// of the previous request contains the date of the last modification.
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Modified-Since
+func (d *RequestDirective) IfModifiedSince() (time.Time, bool) {
+	if v := d.ifModifiedSince; v != nil {
+		return *v, true
+	}
+	return time.Time{}, false
+}
+
+// The max-stale=N request directive indicates that the client allows a stored response
+// that is stale within N seconds. If no N value is specified, the client will accept a
+// stale response of any age.
+func (d *RequestDirective) MaxStale() (uint64, bool) {
+	if v := d.maxStale; v != nil {
+		return *v, true
+	}
+	return 0, false
+}
+
+// The min-fresh=N request directive indicates that the client allows a stored
+// response that is fresh for at least N seconds.
+func (d *RequestDirective) MinFresh() (uint64, bool) {
+	if v := d.minFresh; v != nil {
+		return *v, true
+	}
+	return 0, false
+}
+
+// The client indicates that an already-cached response should be returned. If a cache
+// has a stored response, even a stale one, it will be returned. If no cached response
+// is available, a 504 Gateway Timeout response will be returned.
+func (d *RequestDirective) OnlyIfCached() bool {
+	return d.onlyIfCached
+}
+
+//===========================================================================
+// Response Directive Methods
+//===========================================================================
+
+// The HTTP Expires response header contains the date/time after which the response is
+// considered expired in the context of HTTP caching.
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Expires
+func (d *ResponseDirective) Expires() (time.Time, bool) {
+	if v := d.expires; v != nil {
+		return *v, true
+	}
+	return time.Time{}, false
+}
+
+// The HTTP Last-Modified response header contains a date and time when the origin
+// server believes the resource was last modified. It is used as a validator in
+// conditional requests (If-Modified-Since or If-Unmodified-Since) to determine if a
+// requested resource is the same as one already stored by the client. It is less
+// accurate than an ETag for determining file contents, but can be used as a fallback
+// mechanism if ETags are unavailable.
+//
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Last-Modified
+func (d *ResponseDirective) LastModified() (time.Time, bool) {
+	if v := d.lastModified; v != nil {
+		return *v, true
+	}
+	return time.Time{}, false
+}
+
+// The HTTP ETag (entity tag) response header is an identifier for a specific version
+// of a resource. It lets caches be more efficient and save bandwidth, as a web server
+// does not need to resend a full response if the content has not changed.
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag
+func (d *ResponseDirective) ETag() (string, bool) {
+	if v := d.etag; v != nil {
+		return *v, true
+	}
+	return "", false
+}
+
+// The s-maxage response directive indicates how long the response remains fresh in a
+// shared cache. The s-maxage directive is ignored by private caches, and overrides the
+// value specified by the max-age directive or the Expires header for shared caches,
+// if they are present.
+func (d *ResponseDirective) SMaxAge() (uint64, bool) {
+	if v := d.sMaxAge; v != nil {
+		return *v, true
+	}
+	return 0, false
+}
+
+// The must-revalidate response directive indicates that the response can be stored in
+// caches and can be reused while fresh. If the response becomes stale, it must be
+// validated with the origin server before reuse.
+func (d *ResponseDirective) MustRevalidate() bool {
+	return d.mustRevalidate
+}
+
+// The proxy-revalidate response directive is the equivalent of must-revalidate,
+// but specifically for shared caches only.
+func (d *ResponseDirective) ProxyRevalidate() bool {
+	return d.proxyRevalidate
+}
+
+// The private response directive indicates that the response can be stored only in a
+// private cache (e.g., local caches in browsers).
+func (d *ResponseDirective) Private() bool {
+	return d.private
+}
+
+// The public response directive indicates that the response can be stored in a shared
+// cache. Responses for requests with Authorization header fields must not be stored in
+// a shared cache; however, the public directive will cause such responses to be stored
+// in a shared cache.
+func (d *ResponseDirective) Public() bool {
+	return d.public
+}
+
+// The must-understand response directive indicates that a cache should store the
+// response only if it understands the requirements for caching based on status code.
+// must-understand should be coupled with no-store for fallback behavior.
+func (d *ResponseDirective) MustUnderstand() bool {
+	return d.mustUnderstand
+}
+
+// The immutable response directive indicates that the response will not
+// be updated while it's fresh.
+func (d *ResponseDirective) Immutable() bool {
+	return d.immutable
+}
+
+// The stale-while-revalidate response directive indicates that the cache could reuse
+// a stale response while it revalidates it to a cache.
+func (d *ResponseDirective) StaleWhileRevalidate() (uint64, bool) {
+	if v := d.staleWhileRevalidate; v != nil {
+		return *v, true
+	}
+	return 0, false
+}

--- a/httpcc/directives_test.go
+++ b/httpcc/directives_test.go
@@ -1,0 +1,99 @@
+package httpcc_test
+
+import (
+	"testing"
+
+	"go.rtnl.ai/x/assert"
+	"go.rtnl.ai/x/httpcc"
+)
+
+func TestDirective(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		directive := &httpcc.Directive{}
+
+		maxAge, ok := directive.MaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxAge)
+
+		assert.False(t, directive.NoCache())
+		assert.False(t, directive.NoStore())
+		assert.False(t, directive.NoTransform())
+
+		staleIfError, ok := directive.StaleIfError()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), staleIfError)
+
+		extension := directive.Extensions()
+		assert.Len(t, extension, 0)
+
+		test := directive.Extension("nonexistent")
+		assert.Equal(t, "", test)
+	})
+
+	t.Run("Populated", func(t *testing.T) {})
+}
+
+func TestRequestDirective(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		directive := &httpcc.RequestDirective{}
+
+		ifNoneMatch, ok := directive.IfNoneMatch()
+		assert.False(t, ok)
+		assert.Equal(t, "", ifNoneMatch)
+
+		ifUnmodifiedSince, ok := directive.IfUnmodifiedSince()
+		assert.False(t, ok)
+		assert.True(t, ifUnmodifiedSince.IsZero())
+
+		ifModifiedSince, ok := directive.IfModifiedSince()
+		assert.False(t, ok)
+		assert.True(t, ifModifiedSince.IsZero())
+
+		maxStale, ok := directive.MaxStale()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxStale)
+
+		minFresh, ok := directive.MinFresh()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), minFresh)
+
+		assert.False(t, directive.OnlyIfCached())
+	})
+
+	t.Run("Populated", func(t *testing.T) {})
+}
+
+func TestResponseDirective(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		directive := &httpcc.ResponseDirective{}
+
+		expires, ok := directive.Expires()
+		assert.False(t, ok)
+		assert.True(t, expires.IsZero())
+
+		lastModified, ok := directive.LastModified()
+		assert.False(t, ok)
+		assert.True(t, lastModified.IsZero())
+
+		etag, ok := directive.ETag()
+		assert.False(t, ok)
+		assert.Equal(t, "", etag)
+
+		sMaxAge, ok := directive.SMaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), sMaxAge)
+
+		assert.False(t, directive.MustRevalidate())
+		assert.False(t, directive.ProxyRevalidate())
+		assert.False(t, directive.MustUnderstand())
+		assert.False(t, directive.Private())
+		assert.False(t, directive.Public())
+		assert.False(t, directive.Immutable())
+
+		staleWhileRevalidate, ok := directive.StaleWhileRevalidate()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), staleWhileRevalidate)
+	})
+
+	t.Run("Populated", func(t *testing.T) {})
+}

--- a/httpcc/httpcc.go
+++ b/httpcc/httpcc.go
@@ -1,0 +1,466 @@
+package httpcc
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	// Cache-Control Directives
+	MaxAge               = "max-age"
+	MaxStale             = "max-stale"
+	MinFresh             = "min-fresh"
+	SMaxAge              = "s-maxage"
+	NoCache              = "no-cache"
+	NoStore              = "no-store"
+	NoTransform          = "no-transform"
+	OnlyIfCached         = "only-if-cached"
+	MustRevalidate       = "must-revalidate"
+	ProxyRevalidate      = "proxy-revalidate"
+	MustUnderstand       = "must-understand"
+	Private              = "private"
+	Public               = "public"
+	Immutable            = "immutable"
+	StaleWhileRevalidate = "stale-while-revalidate"
+	StaleIfError         = "stale-if-error"
+)
+
+const (
+	// Header Values
+	CacheControl      = "Cache-Control"
+	LastModified      = "Last-Modified"
+	Expires           = "Expires"
+	ETag              = "ETag"
+	IfNoneMatch       = "If-None-Match"
+	IfModifiedSince   = "If-Modified-Since"
+	IfUnmodifiedSince = "If-Unmodified-Since"
+)
+
+//===========================================================================
+// Request and Response Parsing
+//===========================================================================
+
+// Request fetches the cache control directives from an HTTP request; or if a string is
+// provided, it parses it as though it is  the value of a `Cache-Control` header.
+func Request(req any) (directive *RequestDirective, err error) {
+	switch r := req.(type) {
+	case string:
+		return ParseRequest(r)
+	case *http.Request:
+		// Parse the Cache-Control header from the request.
+		if directive, err = ParseRequest(r.Header.Get(CacheControl)); err != nil {
+			return nil, fmt.Errorf("failed to parse request cache control: %w", err)
+		}
+
+		// Parse the If-None-Match header if it exists.
+		if ifNoneMatch := r.Header.Get(IfNoneMatch); ifNoneMatch != "" {
+			directive.ifNoneMatch = &ifNoneMatch
+		}
+
+		// Parse the If-Unmodified-Since header if it exists.
+		if ifUnmodifiedSince := r.Header.Get(IfUnmodifiedSince); ifUnmodifiedSince != "" {
+			var t time.Time
+			if t, err = http.ParseTime(ifUnmodifiedSince); err != nil {
+				return nil, fmt.Errorf("failed to parse if-unmodified-since time: %w", err)
+			}
+			directive.ifUnmodifiedSince = &t
+		}
+
+		// Parse the If-Modified-Since header if it exists.
+		if ifModifiedSince := r.Header.Get(IfModifiedSince); ifModifiedSince != "" {
+			var t time.Time
+			if t, err = http.ParseTime(ifModifiedSince); err != nil {
+				return nil, fmt.Errorf("failed to parse if-modified-since time: %w", err)
+			}
+			directive.ifModifiedSince = &t
+		}
+		return directive, nil
+	case http.Request:
+		return Request(&r)
+	case *RequestDirective:
+		return r, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T for request cache control parsing", req)
+	}
+}
+
+// Response fetches the cache control directives from an HTTP response; or if a string
+// is provided, it parses it as though it is the value of a `Cache-Control` header.
+func Response(rep any) (directive *ResponseDirective, err error) {
+	switch r := rep.(type) {
+	case string:
+		return ParseResponse(r)
+	case *http.Response:
+		// Parse the Cache-Control header from the response.
+		if directive, err = ParseResponse(r.Header.Get(CacheControl)); err != nil {
+			return nil, fmt.Errorf("failed to parse response cache control: %w", err)
+		}
+
+		// Parse the Expires header if it exists.
+		if expires := r.Header.Get(Expires); expires != "" {
+			var t time.Time
+			if t, err = http.ParseTime(expires); err != nil {
+				return nil, fmt.Errorf("failed to parse expires time: %w", err)
+			}
+			directive.expires = &t
+		}
+
+		// Parse the Last-Modified header if it exists.
+		if lastModified := r.Header.Get(LastModified); lastModified != "" {
+			var t time.Time
+			if t, err = http.ParseTime(lastModified); err != nil {
+				return nil, fmt.Errorf("failed to parse last-modified time: %w", err)
+			}
+			directive.lastModified = &t
+		}
+
+		// Parse the ETag header if it exists.
+		if etag := r.Header.Get(ETag); etag != "" {
+			directive.etag = &etag
+		}
+		return directive, nil
+	case http.Response:
+		return Response(&r)
+	case *ResponseDirective:
+		return r, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T for response cache control parsing", rep)
+	}
+}
+
+//===========================================================================
+// Cache-Control Directive Parsing
+//===========================================================================
+
+// ParseRequest converts a request cache control header string into a RequestDirective.
+func ParseRequest(cc string) (_ *RequestDirective, err error) {
+	var (
+		dir    RequestDirective
+		tokens []*TokenPair
+	)
+
+	dir.extensions = make(map[string]string)
+	if tokens, err = ParseRequestDirectives(cc); err != nil {
+		return nil, fmt.Errorf("failed to parse tokens: %w", err)
+	}
+
+	for _, token := range tokens {
+		name := strings.ToLower(token.Name)
+		switch name {
+		case MaxAge:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse max-age: %w", err)
+			}
+			dir.maxAge = &val
+		case MaxStale:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse max-stale: %w", err)
+			}
+			dir.maxStale = &val
+		case MinFresh:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse min-fresh: %w", err)
+			}
+			dir.minFresh = &val
+		case StaleIfError:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse stale-if-error: %w", err)
+			}
+			dir.staleIfError = &val
+		case NoCache:
+			dir.noCache = true
+		case NoStore:
+			dir.noStore = true
+		case NoTransform:
+			dir.noTransform = true
+		case OnlyIfCached:
+			dir.onlyIfCached = true
+		default:
+			if token.Value == "" {
+				token.Value = token.Name
+			}
+			dir.extensions[name] = token.Value
+		}
+	}
+
+	return &dir, nil
+}
+
+// ParseResponse converts a response cache control header string into a ResponseDirective.
+func ParseResponse(cc string) (_ *ResponseDirective, err error) {
+	var (
+		dir    ResponseDirective
+		tokens []*TokenPair
+	)
+
+	dir.extensions = make(map[string]string)
+	if tokens, err = ParseResponseDirectives(cc); err != nil {
+		return nil, fmt.Errorf("failed to parse tokens: %w", err)
+	}
+
+	for _, token := range tokens {
+		name := strings.ToLower(token.Name)
+		switch name {
+		case MaxAge:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse max-age: %w", err)
+			}
+			dir.maxAge = &val
+		case SMaxAge:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse s-maxage: %w", err)
+			}
+			dir.sMaxAge = &val
+		case StaleWhileRevalidate:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse stale-while-revalidate: %w", err)
+			}
+			dir.staleWhileRevalidate = &val
+		case StaleIfError:
+			var val uint64
+			if val, err = parseUint64(token.Value); err != nil {
+				return nil, fmt.Errorf("could not parse stale-if-error: %w", err)
+			}
+			dir.staleIfError = &val
+		case NoCache:
+			dir.noCache = true
+		case MustRevalidate:
+			dir.mustRevalidate = true
+		case ProxyRevalidate:
+			dir.proxyRevalidate = true
+		case NoStore:
+			dir.noStore = true
+		case Private:
+			dir.private = true
+		case Public:
+			dir.public = true
+		case MustUnderstand:
+			dir.mustUnderstand = true
+		case NoTransform:
+			dir.noTransform = true
+		case Immutable:
+			dir.immutable = true
+		default:
+			if token.Value == "" {
+				token.Value = token.Name
+			}
+			dir.extensions[name] = token.Value
+		}
+	}
+
+	return &dir, nil
+}
+
+//===========================================================================
+// Directive Parser
+//===========================================================================
+
+type TokenPair struct {
+	Name  string
+	Value string
+}
+
+type TokenValuePolicy uint8
+
+const (
+	NoArgument TokenValuePolicy = iota
+	TokenOnly
+	QuotedStringOnly
+	AnyTokenValue
+)
+
+type directiveValidator func(string) TokenValuePolicy
+
+// ParseRequestDirective parses a single token with validation for request directives.
+func ParseRequestDirective(s string) (*TokenPair, error) {
+	return parseDirective(s, func(name string) TokenValuePolicy {
+		switch name {
+		case MaxAge, MaxStale, MinFresh, StaleIfError:
+			return TokenOnly
+		case NoCache, NoStore, NoTransform, OnlyIfCached:
+			return NoArgument
+		default:
+			return AnyTokenValue
+		}
+	})
+}
+
+// ParseResponseDirective parses a single token with validation for response directives.
+func ParseResponseDirective(s string) (*TokenPair, error) {
+	return parseDirective(s, func(name string) TokenValuePolicy {
+		switch name {
+		case MaxAge, SMaxAge, StaleWhileRevalidate, StaleIfError:
+			return TokenOnly
+		case NoCache, MustRevalidate, ProxyRevalidate, NoStore, Private, Public, MustUnderstand, NoTransform, Immutable:
+			return NoArgument
+		default:
+			return AnyTokenValue
+		}
+	})
+}
+
+// Handles a single token directive using the specified validation function to determine
+// what the token pair policy is and how to construct the TokenPair.
+func parseDirective(s string, ccd directiveValidator) (pair *TokenPair, err error) {
+	s = strings.TrimSpace(s)
+	i := strings.IndexByte(s, '=')
+	if i == -1 {
+		return &TokenPair{Name: s, Value: ""}, nil
+	}
+
+	pair = &TokenPair{Name: strings.TrimSpace(s[:i])}
+	v := strings.TrimSpace(s[i+1:])
+	if len(v) == 0 {
+		// `key=` should be a parse error but it's HTTP so we return as if nothing happened.
+		return pair, nil
+	}
+
+	switch ccd(pair.Name) {
+	case TokenOnly:
+		if v[0] == '"' {
+			return nil, fmt.Errorf(`invalid value for %s (quoted string not allowed)`, pair.Name)
+		}
+	case QuotedStringOnly:
+		if v[0] != '"' {
+			return nil, fmt.Errorf(`invalid value for %s (expected quoted string)`, pair.Name)
+		}
+
+		var tmp string
+		if tmp, err = strconv.Unquote(v); err != nil {
+			return nil, fmt.Errorf(`invalid value for %s (unquoting failed: %w)`, pair.Name, err)
+		}
+		v = tmp
+	case AnyTokenValue:
+		if v[0] == '"' {
+			var tmp string
+			if tmp, err = strconv.Unquote(v); err != nil {
+				return nil, fmt.Errorf(`invalid value for %s (unquoting failed: %w)`, pair.Name, err)
+			}
+			v = tmp
+		}
+	case NoArgument:
+		if len(v) > 0 {
+			return nil, fmt.Errorf(`invalid value for %s (no argument expected)`, pair.Name)
+		}
+	}
+
+	pair.Value = v
+	return pair, nil
+}
+
+// Parses all the directives in a request cache control header string.
+func ParseRequestDirectives(cc string) (tokens []*TokenPair, err error) {
+	return parseDirectives(cc, ParseRequestDirective)
+}
+
+// Parses all the directives in a response cache control header string.
+func ParseResponseDirectives(cc string) (tokens []*TokenPair, err error) {
+	return parseDirectives(cc, ParseResponseDirective)
+}
+
+// Parses the string into token pairs based on the policies and validation provided
+// by the handler parsing function p.
+func parseDirectives(s string, p func(string) (*TokenPair, error)) (tokens []*TokenPair, err error) {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	scanner.Split(commaSeparatedWords)
+
+	for scanner.Scan() {
+		var token *TokenPair
+		if token, err = p(scanner.Text()); err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, token)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}
+
+// Scan to find comma separated tokens, handling leading spaces and consecutive spaces.
+func commaSeparatedWords(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// Skip leading spaces.
+	start := 0
+	for width := 0; start < len(data); start += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[start:])
+		if !isSpace(r) {
+			break
+		}
+	}
+
+	// Scan until we find a comma. Keep track of consecutive whitespaces.
+	var ws int
+	for width, i := 0, start; i < len(data); i += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[i:])
+		switch {
+		case isSpace(r):
+			ws++
+		case r == ',':
+			return i + width, data[start : i-ws], nil
+		default:
+			ws = 0
+		}
+	}
+
+	// If we're at EOF, we have a final, non-empty, non-terminated word. Return it.
+	if atEOF && len(data) > start {
+		return len(data), data[start : len(data)-ws], nil
+	}
+
+	// Request more data.
+	return start, nil, nil
+}
+
+// Checks if the rune is a space character according to the HTTP spec.
+func isSpace(r rune) bool {
+	if r <= '\u00FF' {
+		// Obvious ASCII ones: \t through \r plus space. Plus some Latin-1 spaces.
+		switch r {
+		case ' ', '\t', '\n', '\v', '\f', '\r':
+			return true
+		case '\u0085', '\u00A0':
+			return true
+		default:
+			return false
+		}
+	}
+
+	// High-valued spaces.
+	if '\u2000' <= r && r <= '\u200A' {
+		return true
+	}
+
+	switch r {
+	case '\u1680', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000':
+		return true
+	}
+
+	return false
+}
+
+func parseUint64(v string) (i uint64, err error) {
+	if v == "" {
+		return 0, nil // Default value for empty strings.
+	}
+
+	if i, err = strconv.ParseUint(v, 10, 64); err != nil {
+		return 0, err
+	}
+	return i, nil
+}

--- a/httpcc/httpcc_test.go
+++ b/httpcc/httpcc_test.go
@@ -1,0 +1,548 @@
+package httpcc_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"go.rtnl.ai/x/assert"
+	. "go.rtnl.ai/x/httpcc"
+)
+
+func TestRequest(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		assert.Ok(t, err, "failed to create request")
+		directive, err := Request(*req)
+		assert.Ok(t, err, "failed to parse request cache control")
+
+		maxAge, ok := directive.MaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxAge)
+
+		assert.False(t, directive.NoCache())
+		assert.False(t, directive.NoStore())
+		assert.False(t, directive.NoTransform())
+
+		staleIfError, ok := directive.StaleIfError()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), staleIfError)
+
+		extension := directive.Extensions()
+		assert.Len(t, extension, 0)
+
+		test := directive.Extension("nonexistent")
+		assert.Equal(t, "", test)
+
+		ifNoneMatch, ok := directive.IfNoneMatch()
+		assert.False(t, ok)
+		assert.Equal(t, "", ifNoneMatch)
+
+		ifUnmodifiedSince, ok := directive.IfUnmodifiedSince()
+		assert.False(t, ok)
+		assert.True(t, ifUnmodifiedSince.IsZero())
+
+		ifModifiedSince, ok := directive.IfModifiedSince()
+		assert.False(t, ok)
+		assert.True(t, ifModifiedSince.IsZero())
+
+		maxStale, ok := directive.MaxStale()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxStale)
+
+		minFresh, ok := directive.MinFresh()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), minFresh)
+
+		assert.False(t, directive.OnlyIfCached())
+	})
+
+	t.Run("NoCacheControl", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		assert.Ok(t, err, "failed to create request")
+
+		ts := time.Date(2025, 4, 7, 13, 21, 43, 0, time.UTC)
+
+		req.Header.Set(IfNoneMatch, "myetag")
+		req.Header.Set(IfUnmodifiedSince, ts.Format(http.TimeFormat))
+		req.Header.Set(IfModifiedSince, ts.Format(http.TimeFormat))
+
+		directive, err := Request(*req)
+		assert.Ok(t, err, "failed to parse request cache control")
+
+		ifNoneMatch, ok := directive.IfNoneMatch()
+		assert.True(t, ok)
+		assert.Equal(t, "myetag", ifNoneMatch)
+
+		ifUnmodifiedSince, ok := directive.IfUnmodifiedSince()
+		assert.True(t, ok)
+		assert.Equal(t, ts, ifUnmodifiedSince)
+
+		ifModifiedSince, ok := directive.IfModifiedSince()
+		assert.True(t, ok)
+		assert.Equal(t, ts, ifModifiedSince)
+
+		maxAge, ok := directive.MaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxAge)
+	})
+
+	t.Run("CacheControl", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		assert.Ok(t, err, "failed to create request")
+
+		ts := time.Date(2025, 4, 7, 13, 21, 43, 0, time.UTC)
+
+		req.Header.Set(CacheControl, "max-age=604800, no-transform, stale-if-error=86400")
+		req.Header.Set(IfNoneMatch, "myetag")
+		req.Header.Set(IfUnmodifiedSince, ts.Format(http.TimeFormat))
+		req.Header.Set(IfModifiedSince, ts.Format(http.TimeFormat))
+
+		directive, err := Request(*req)
+		assert.Ok(t, err, "failed to parse request cache control")
+
+		maxAge, ok := directive.MaxAge()
+		assert.True(t, ok)
+		assert.Equal(t, uint64(604800), maxAge)
+
+		assert.False(t, directive.NoCache())
+		assert.False(t, directive.NoStore())
+		assert.True(t, directive.NoTransform())
+
+		staleIfError, ok := directive.StaleIfError()
+		assert.True(t, ok)
+		assert.Equal(t, uint64(86400), staleIfError)
+
+		extension := directive.Extensions()
+		assert.Len(t, extension, 0)
+
+		ifNoneMatch, ok := directive.IfNoneMatch()
+		assert.True(t, ok)
+		assert.Equal(t, "myetag", ifNoneMatch)
+
+		ifUnmodifiedSince, ok := directive.IfUnmodifiedSince()
+		assert.True(t, ok)
+		assert.Equal(t, ts, ifUnmodifiedSince)
+
+		ifModifiedSince, ok := directive.IfModifiedSince()
+		assert.True(t, ok)
+		assert.Equal(t, ts, ifModifiedSince)
+
+		// Quick pass-through test
+		dir2, err := Request(directive)
+		assert.Ok(t, err, "failed to parse request cache control from directive")
+		assert.Equal(t, directive, dir2, "directive did not match original")
+	})
+
+	t.Run("BadType", func(t *testing.T) {
+		_, err := Request(1233)
+		assert.EqualError(t, err, "unsupported type int for request cache control parsing")
+	})
+}
+
+func TestResponse(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		rep := &http.Response{}
+		directive, err := Response(*rep)
+		assert.Ok(t, err, "failed to parse response cache control")
+
+		maxAge, ok := directive.MaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxAge)
+
+		assert.False(t, directive.NoCache())
+		assert.False(t, directive.NoStore())
+		assert.False(t, directive.NoTransform())
+
+		staleIfError, ok := directive.StaleIfError()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), staleIfError)
+
+		extension := directive.Extensions()
+		assert.Len(t, extension, 0)
+
+		test := directive.Extension("nonexistent")
+		assert.Equal(t, "", test)
+
+		expires, ok := directive.Expires()
+		assert.False(t, ok)
+		assert.True(t, expires.IsZero())
+
+		lastModified, ok := directive.LastModified()
+		assert.False(t, ok)
+		assert.True(t, lastModified.IsZero())
+
+		etag, ok := directive.ETag()
+		assert.False(t, ok)
+		assert.Equal(t, "", etag)
+
+		sMaxAge, ok := directive.SMaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), sMaxAge)
+
+		assert.False(t, directive.MustRevalidate())
+		assert.False(t, directive.ProxyRevalidate())
+		assert.False(t, directive.MustUnderstand())
+		assert.False(t, directive.Private())
+		assert.False(t, directive.Public())
+		assert.False(t, directive.Immutable())
+
+		staleWhileRevalidate, ok := directive.StaleWhileRevalidate()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), staleWhileRevalidate)
+	})
+
+	t.Run("BadType", func(t *testing.T) {
+		_, err := Response(1233)
+		assert.EqualError(t, err, "unsupported type int for response cache control parsing")
+	})
+
+	t.Run("NoCacheControl", func(t *testing.T) {
+		rep := &http.Response{
+			Header: make(http.Header),
+		}
+
+		ts := time.Date(2025, 4, 7, 13, 21, 43, 0, time.UTC)
+		rep.Header.Set(Expires, ts.Format(http.TimeFormat))
+		rep.Header.Set(LastModified, ts.Format(http.TimeFormat))
+		rep.Header.Set(ETag, "myetag")
+
+		directive, err := Response(*rep)
+		assert.Ok(t, err, "failed to parse response cache control")
+
+		expires, ok := directive.Expires()
+		assert.True(t, ok)
+		assert.Equal(t, ts, expires)
+
+		lastModified, ok := directive.LastModified()
+		assert.True(t, ok)
+		assert.Equal(t, ts, lastModified)
+
+		etag, ok := directive.ETag()
+		assert.True(t, ok)
+		assert.Equal(t, "myetag", etag)
+
+		maxAge, ok := directive.MaxAge()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), maxAge)
+	})
+
+	t.Run("CacheControl", func(t *testing.T) {
+		rep := &http.Response{
+			Header: make(http.Header),
+		}
+
+		ts := time.Date(2025, 4, 7, 13, 21, 43, 0, time.UTC)
+
+		rep.Header.Set(CacheControl, "max-age=604800, must-revalidate")
+		rep.Header.Set(Expires, ts.Format(http.TimeFormat))
+		rep.Header.Set(LastModified, ts.Format(http.TimeFormat))
+		rep.Header.Set(ETag, "myetag")
+
+		directive, err := Response(*rep)
+		assert.Ok(t, err, "failed to parse response cache control")
+
+		maxAge, ok := directive.MaxAge()
+		assert.True(t, ok)
+		assert.Equal(t, uint64(604800), maxAge)
+
+		assert.True(t, directive.MustRevalidate())
+
+		assert.False(t, directive.NoCache())
+		assert.False(t, directive.NoStore())
+		assert.False(t, directive.NoTransform())
+
+		staleIfError, ok := directive.StaleIfError()
+		assert.False(t, ok)
+		assert.Equal(t, uint64(0), staleIfError)
+
+		extension := directive.Extensions()
+		assert.Len(t, extension, 0)
+
+		expires, ok := directive.Expires()
+		assert.True(t, ok)
+		assert.Equal(t, ts, expires)
+
+		lastModified, ok := directive.LastModified()
+		assert.True(t, ok)
+		assert.Equal(t, ts, lastModified)
+
+		etag, ok := directive.ETag()
+		assert.True(t, ok)
+		assert.Equal(t, "myetag", etag)
+
+		// Quick pass-through test
+		dir2, err := Response(directive)
+		assert.Ok(t, err, "failed to parse response cache control from directive")
+		assert.Equal(t, directive, dir2)
+	})
+}
+
+func TestParseResponseDirectives(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		var responseDirectives = []struct {
+			cc       string
+			expected map[string]any
+		}{
+			{"max-age=604800", map[string]any{"max-age": uint64(604800)}},
+			{"max-age=", map[string]any{"max-age": uint64(0)}},
+			{"s-maxage=604800", map[string]any{"s-maxage": uint64(604800)}},
+			{"no-cache", map[string]any{"no-cache": true}},
+			{"max-age=604800, must-revalidate", map[string]any{"max-age": uint64(604800), "must-revalidate": true}},
+			{"max-age=604800, proxy-revalidate", map[string]any{"max-age": uint64(604800), "proxy-revalidate": true}},
+			{"no-store", map[string]any{"no-store": true}},
+			{"private", map[string]any{"private": true}},
+			{"private=", map[string]any{"private": true}},
+			{"public", map[string]any{"public": true}},
+			{"public, max-age=604800", map[string]any{"public": true, "max-age": uint64(604800)}},
+			{"must-understand, no-store", map[string]any{"must-understand": true, "no-store": true}},
+			{"no-transform,", map[string]any{"no-transform": true}},
+			{"public, max-age=604800, immutable", map[string]any{"public": true, "max-age": uint64(604800), "immutable": true}},
+			{"max-age=604800, stale-while-revalidate=86400", map[string]any{"max-age": uint64(604800), "stale-while-revalidate": uint64(86400)}},
+			{"max-age=604800, stale-if-error=86400", map[string]any{"max-age": uint64(604800), "stale-if-error": uint64(86400)}},
+			{"max-age=31536000, immutable", map[string]any{"max-age": uint64(31536000), "immutable": true}},
+			{"max-age=0, must-revalidate", map[string]any{"max-age": uint64(0), "must-revalidate": true}},
+			{"hello=\"world\"", map[string]any{"hello": "world"}},
+			{"ext=\"नमस्ते\"", map[string]any{"ext": "नमस्ते"}},
+			{"max-age=604800, ext=\"नमस्ते\"", map[string]any{"max-age": uint64(604800), "ext": "नमस्ते"}},
+			{"foo,", map[string]any{"foo": "foo"}},
+			{"FOO,", map[string]any{"foo": "FOO"}},
+		}
+
+		for _, cc := range responseDirectives {
+			directives, err := Response(cc.cc)
+			assert.Ok(t, err, "failed to parse response directives for %q", cc.cc)
+			assertDirectives(t, directives, cc.expected)
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		var testCases = []struct {
+			cc   string
+			errs string
+		}{
+			{"max-age=-1", "could not parse max-age: strconv.ParseUint: parsing \"-1\": invalid syntax"},
+			{"s-maxage=foo", "could not parse s-maxage: strconv.ParseUint: parsing \"foo\": invalid syntax"},
+			{"stale-while-revalidate=foo", "could not parse stale-while-revalidate: strconv.ParseUint: parsing \"foo\": invalid syntax"},
+			{"stale-if-error=foo", "could not parse stale-if-error: strconv.ParseUint: parsing \"foo\": invalid syntax"},
+			{"public=8600", "failed to parse tokens: invalid value for public (no argument expected)"},
+			{"max-age=\"86000\"", "failed to parse tokens: invalid value for max-age (quoted string not allowed)"},
+			{"foo=\"notenclosed", "failed to parse tokens: invalid value for foo (unquoting failed: invalid syntax)"},
+		}
+
+		for _, tc := range testCases {
+			_, err := Response(tc.cc)
+			assert.EqualError(t, err, tc.errs, "error message did not contain expected text for %q", tc.cc)
+		}
+	})
+}
+
+func TestParseRequestDirectives(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		var requestDirectives = []struct {
+			cc       string
+			expected map[string]any
+		}{
+			{"no-cache", map[string]any{"no-cache": true}},
+			{"no-store", map[string]any{"no-store": true}},
+			{" max-age=10800 ", map[string]any{"max-age": uint64(10800)}},
+			{"max-stale=3600", map[string]any{"max-stale": uint64(3600)}},
+			{"min-fresh=600", map[string]any{"min-fresh": uint64(600)}},
+			{"no-transform", map[string]any{"no-transform": true}},
+			{"only-if-cached", map[string]any{"only-if-cached": true}},
+			{"max-age=604800, stale-if-error=86400", map[string]any{"max-age": uint64(604800), "stale-if-error": uint64(86400)}},
+			{"hello=\"world\"", map[string]any{"hello": "world"}},
+			{"ext=\"नमस्ते\"", map[string]any{"ext": "नमस्ते"}},
+			{"max-age=604800, ext=\"नमस्ते\"", map[string]any{"max-age": uint64(604800), "ext": "नमस्ते"}},
+			{"foo", map[string]any{"foo": "foo"}},
+			{"FOO,", map[string]any{"foo": "FOO"}},
+		}
+
+		for _, cc := range requestDirectives {
+			directives, err := Request(cc.cc)
+			assert.Ok(t, err, "failed to parse request directives for %q", cc.cc)
+			assertDirectives(t, directives, cc.expected)
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		var testCases = []struct {
+			cc   string
+			errs string
+		}{
+			{"max-age=-1", "could not parse max-age: strconv.ParseUint: parsing \"-1\": invalid syntax"},
+			{"max-age=\"86000\"", "failed to parse tokens: invalid value for max-age (quoted string not allowed)"},
+			{"max-stale=foo", "could not parse max-stale: strconv.ParseUint: parsing \"foo\": invalid syntax"},
+			{"min-fresh=foo", "could not parse min-fresh: strconv.ParseUint: parsing \"foo\": invalid syntax"},
+			{"only-if-cached=8600", "failed to parse tokens: invalid value for only-if-cached (no argument expected)"},
+			{"no-cache=8600", "failed to parse tokens: invalid value for no-cache (no argument expected)"},
+			{"stale-if-error=foo", "could not parse stale-if-error: strconv.ParseUint: parsing \"foo\": invalid syntax"},
+			{"foo=\"notenclosed", "failed to parse tokens: invalid value for foo (unquoting failed: invalid syntax)"},
+		}
+
+		for _, tc := range testCases {
+			_, err := Request(tc.cc)
+			assert.EqualError(t, err, tc.errs, "error message did not contain expected text for %q", tc.cc)
+		}
+	})
+}
+
+func TestParseEmpty(t *testing.T) {
+	t.Run("ResponseDirectives", func(t *testing.T) {
+		tokens, err := ParseResponseDirectives("")
+		assert.Ok(t, err)
+		assert.Len(t, tokens, 0, "Expected no tokens for empty string")
+	})
+
+	t.Run("RequestDirectives", func(t *testing.T) {
+		tokens, err := ParseRequestDirectives("")
+		assert.Ok(t, err)
+		assert.Len(t, tokens, 0, "Expected no tokens for empty string")
+	})
+}
+
+func TestSkipSpaces(t *testing.T) {
+	cc := "  \u0085   \u00a0 max-age=604800\u1680 \u2028, \u2000ext=\"नमस्ते\", \u200A \t no-cache \u2003, \v\n \u202F  no-store \f\r \u2029   \u205f \u3000 "
+
+	t.Run("RequestDirective", func(t *testing.T) {
+		tokens, err := ParseRequestDirectives(cc)
+		assert.Ok(t, err)
+		assert.Equal(t, 4, len(tokens), "Expected 4 tokens for %q", cc)
+	})
+
+	t.Run("ResponseDirective", func(t *testing.T) {
+		tokens, err := ParseResponseDirectives(cc)
+		assert.Ok(t, err)
+		assert.Equal(t, 4, len(tokens), "Expected 4 tokens for %q", cc)
+	})
+}
+
+func assertDirectives(t *testing.T, directives any, expected map[string]any) {
+	t.Helper()
+	for name, expectedValue := range expected {
+		assertDirective(t, directives, name, expectedValue)
+	}
+}
+
+func assertDirective(t *testing.T, directive any, name string, expected any) {
+	t.Helper()
+
+	switch d := directive.(type) {
+	case *RequestDirective:
+		switch name {
+		case MaxAge:
+			maxAge, ok := d.MaxAge()
+			assert.True(t, ok, "expected max-age to be set")
+			assert.Equal(t, expected, maxAge, "max-age did not match expected value")
+		case NoCache:
+			assert.Equal(t, expected, d.NoCache(), "no-cache did not match expected value")
+		case NoStore:
+			assert.Equal(t, expected, d.NoStore(), "no-store did not match expected value")
+		case NoTransform:
+			assert.Equal(t, expected, d.NoTransform(), "no-transform did not match expected value")
+		case StaleIfError:
+			staleIfError, ok := d.StaleIfError()
+			assert.True(t, ok, "expected stale-if-error to be set")
+			assert.Equal(t, expected, staleIfError, "stale-if-error did not match expected value")
+		case IfNoneMatch:
+			ifNoneMatch, ok := d.IfNoneMatch()
+			assert.True(t, ok, "expected if-none-match to be set")
+			assert.Equal(t, expected, ifNoneMatch, "if-none-match did not match expected value")
+		case IfUnmodifiedSince:
+			ifUnmodifiedSince, ok := d.IfUnmodifiedSince()
+			assert.True(t, ok, "expected if-unmodified-since to be set")
+			assert.Equal(t, expected, ifUnmodifiedSince, "if-unmodified-since did not match expected value")
+		case IfModifiedSince:
+			ifModifiedSince, ok := d.IfModifiedSince()
+			assert.True(t, ok, "expected if-modified-since to be set")
+			assert.Equal(t, expected, ifModifiedSince, "if-modified-since did not match expected value")
+		case MaxStale:
+			maxStale, ok := d.MaxStale()
+			assert.True(t, ok, "expected max-stale to be set")
+			assert.Equal(t, expected, maxStale, "max-stale did not match expected value")
+		case MinFresh:
+			minFresh, ok := d.MinFresh()
+			assert.True(t, ok, "expected min-fresh to be set")
+			assert.Equal(t, expected, minFresh, "min-fresh did not match expected value")
+		case OnlyIfCached:
+			assert.Equal(t, expected, d.OnlyIfCached(), "only-if-cached did not match expected value")
+		default:
+			value := d.Extension(name)
+			assert.Equal(t, expected, value, "extension %q did not match expected value", name)
+		}
+	case *ResponseDirective:
+		switch name {
+		case MaxAge:
+			maxAge, ok := d.MaxAge()
+			assert.True(t, ok, "expected max-age to be set")
+			assert.Equal(t, expected, maxAge, "max-age did not match expected value")
+		case NoCache:
+			assert.Equal(t, expected, d.NoCache(), "no-cache did not match expected value")
+		case NoStore:
+			assert.Equal(t, expected, d.NoStore(), "no-store did not match expected value")
+		case NoTransform:
+			assert.Equal(t, expected, d.NoTransform(), "no-transform did not match expected value")
+		case StaleIfError:
+			staleIfError, ok := d.StaleIfError()
+			assert.True(t, ok, "expected stale-if-error to be set")
+			assert.Equal(t, expected, staleIfError, "stale-if-error did not match expected value")
+		case Expires:
+			expires, ok := d.Expires()
+			assert.True(t, ok, "expected expires to be set")
+			assert.Equal(t, expected, expires, "expires did not match expected value")
+		case LastModified:
+			lastModified, ok := d.LastModified()
+			assert.True(t, ok, "expected last-modified to be set")
+			assert.Equal(t, expected, lastModified, "last-modified did not match expected value")
+		case ETag:
+			etag, ok := d.ETag()
+			assert.True(t, ok, "expected etag to be set")
+			assert.Equal(t, expected, etag, "etag did not match expected value")
+		case SMaxAge:
+			sMaxAge, ok := d.SMaxAge()
+			assert.True(t, ok, "expected s-maxage to be set")
+			assert.Equal(t, expected, sMaxAge, "s-maxage did not match expected value")
+		case MustRevalidate:
+			assert.Equal(t, expected, d.MustRevalidate(), "must-revalidate did not match expected value")
+		case ProxyRevalidate:
+			assert.Equal(t, expected, d.ProxyRevalidate(), "proxy-revalidate did not match expected value")
+		case MustUnderstand:
+			assert.Equal(t, expected, d.MustUnderstand(), "must-understand did not match expected value")
+		case Private:
+			assert.Equal(t, expected, d.Private(), "private did not match expected value")
+		case Public:
+			assert.Equal(t, expected, d.Public(), "public did not match expected value")
+		case Immutable:
+			assert.Equal(t, expected, d.Immutable(), "immutable did not match expected value")
+		case StaleWhileRevalidate:
+			staleWhileRevalidate, ok := d.StaleWhileRevalidate()
+			assert.True(t, ok, "expected stale-while-revalidate to be set")
+			assert.Equal(t, expected, staleWhileRevalidate, "stale-while-revalidate did not match expected value")
+		default:
+			value := d.Extension(name)
+			assert.Equal(t, expected, value, "extension %q did not match expected value", name)
+		}
+	case *Directive:
+		switch name {
+		case MaxAge:
+			maxAge, ok := d.MaxAge()
+			assert.True(t, ok, "expected max-age to be set")
+			assert.Equal(t, expected, maxAge, "max-age did not match expected value")
+		case NoCache:
+			assert.Equal(t, expected, d.NoCache(), "no-cache did not match expected value")
+		case NoStore:
+			assert.Equal(t, expected, d.NoStore(), "no-store did not match expected value")
+		case NoTransform:
+			assert.Equal(t, expected, d.NoTransform(), "no-transform did not match expected value")
+		case StaleIfError:
+			staleIfError, ok := d.StaleIfError()
+			assert.True(t, ok, "expected stale-if-error to be set")
+			assert.Equal(t, expected, staleIfError, "stale-if-error did not match expected value")
+		default:
+			value := d.Extension(name)
+			assert.Equal(t, expected, value, "extension %q did not match expected value", name)
+		}
+	default:
+		t.Fatalf("Unknown directive type: %T", directive)
+	}
+}


### PR DESCRIPTION
### Scope of changes

Adds a small package that can parse HTTP Cache-Control headers.

Fixes SC-33614

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?