### PR TITLE
Port go-querystring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is single repository that stores many, independent small subpackages. This 
 - [noplog](https://go.rtnl.ai/x/noplog): no operation logger to capture internal logging with no output
 - [out](https://go.rtnl.ai/x/out): hierarchical logger to manage logging verbosity to stdout
 - [probez](https://go.rtnl.ai/x/probez): http handlers for kubernetes probes (livez, healthz, and readyz)
+- [query](https://go.rtnl.ai/x/query): encode struct values as a url query string
 - [radish](https://go.rtnl.ai/x/radish): run asynchronous tasks
 - [randstr](https://go.rtnl.ai/x/randstr): generate random strings using the crypto/rand package as efficiently as possible
 - [semver](https://go.rtnl.ai/x/semver): allows parsing and comparison of semantic versioning numbers.

--- a/query/README.md
+++ b/query/README.md
@@ -1,0 +1,27 @@
+# Query
+
+Encodes structs into URL query parameters. This is a port of [github.com/google/go-querystring](https://github.com/google/go-querystring).
+
+## Usage
+
+```go
+import "go.rtnl.ai/x/query"
+```
+
+This package allows you to construct a URL using a struct that represents URL query parameters and to enforce the type safety of those parameters. This is done through a `query.Values()` function that reads struct tags to create the raw query as shown below:
+
+```go
+type PageQuery struct {
+    Page int `url:"page"`
+    Size int `url:"page_size"`
+    Order string `url:"order"`
+    Archives bool `url:"archives"`
+}
+
+query := PageQuery{ 4, 100, "asc", true }
+v, _ := query.Values(opt)
+fmt.Print(v.Encode())
+// page=4&page_size=100&order=asc&archives=true
+```
+
+Currently this package only performs encoding of query values, not decoding. Generally speaking we use `gin.BindQuery` for decoding values in our web applications.

--- a/query/query.go
+++ b/query/query.go
@@ -1,0 +1,315 @@
+// Library ported and adapted from https://github.com/google/go-querystring
+// Copyright (c) 2013 Google. All rights reserved.
+package query
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively to encode each
+// struct field as a URL parameter unless:
+//
+//   - the field's tag is "-", or
+//   - the field is empty and its tag specifies the "omitempty" option.
+//
+// The empty values are false, 0, any nil pointer or interface value, and any array,
+// slice, map, or string of zero length, and any type (such as time.Time) that returns
+// true for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be specified via a
+// tag value (recommended). The "url" key in the tag value is the key name, followed by
+// an optional comma and options. Examples:
+//
+// // Field is ignored by this package
+// Field int `url:"-"`
+//
+// // Field appears as URL parameter "myParam"
+// Field int `url:"myParam"
+//
+// // Field appears as URL parameter "myParam", but only if non-empty
+// Field int `url:"myParam,omitempty"`
+//
+// // Field appears as URL parameter "Field" (the default), but only if non-empty.
+// // Note the leading comma required for options
+// Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules apply:
+//
+// Bool values are encoded as "true" or "false" unless the "int" option is specified,
+// in which case they are encoded as "1" or "0".
+//
+// time.Time values default to RFC3339 format. Including the "unix" option signals that
+// the field should be encoded as a Unix time, and unixmilli and unixnano will encode
+// the number of milliseconds and nanoseconds since the Unix epoch. Including the
+// "layout" tag separate from the "url" tag specifies a custom time format layout.
+//
+// Slice and array values are encoded as multiple instances of the same parameter name.
+// Including the "comma" option signals that the field should be encoded as a single
+// parameter with comma-separated values. Including the "space" or "semicolon" options
+// will similarly delimit the slices. The "brackets" option signals that multiple URL
+// values should have "[]" appended to the value name. "numbered" will append a number to
+// the end of each instance of the value name.
+//
+// Anonymous struct fields are treated as if their inner fields were part of the outer
+// struct, subject to the usual rules. An anonymous struct with a name given in its
+// URL tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// Nested structs have their fields processed recursively and are encoded including the
+// parent fields in the value names for scoping. For example:
+//
+// "user[name]=acme&user[addr][postcode]=12345&user[addr][city]=Metropolis"
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included as
+// multiple URL values of the same name.
+func Values(v any) (url.Values, error) {
+	values := make(url.Values)
+	if v == nil {
+		return values, nil
+	}
+
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return values, nil
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+var (
+	timeType    = reflect.TypeOf(time.Time{})
+	encoderType = reflect.TypeOf(new(Encoder)).Elem()
+)
+
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+
+		if name == "" {
+			if sf.Anonymous {
+				v := reflect.Indirect(sv)
+				if v.IsValid() && v.Kind() == reflect.Struct {
+					embedded = append(embedded, v)
+					continue
+				}
+			}
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			// if sv is a nil pointer and the custom encoder is defined on a non-pointer
+			// method receiver, set sv to the zero value of the underlying type.
+			if !reflect.Indirect(sv).IsValid() && sv.Type().Elem().Implements(encoderType) {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// recursively dereference pointers. break on nil pointers
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			if sv.Len() == 0 {
+				// empty slice, skip
+				continue
+			}
+
+			var delim string
+			if opts.Contains("comma") {
+				delim = ","
+			} else if opts.Contains("space") {
+				delim = " "
+			} else if opts.Contains("semicolon") {
+				delim = ";"
+			} else if opts.Contains("brackets") {
+				name += "[]"
+			} else {
+				delim = sf.Tag.Get("del")
+			}
+
+			if delim != "" {
+				sb := new(strings.Builder)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						sb.WriteString(delim)
+					}
+					sb.WriteString(valueRepr(sv.Index(i), opts, sf))
+				}
+				values.Add(name, sb.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					k := name
+					if opts.Contains("numbered") {
+						k = fmt.Sprintf("%s%d", name, i)
+					}
+					values.Add(k, valueRepr(sv.Index(i), opts, sf))
+				}
+			}
+			continue
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueRepr(sv, opts, sf))
+			continue
+		}
+
+		if sv.Kind() == reflect.Struct {
+			if err := reflectValue(values, sv, name); err != nil {
+				return err
+			}
+			continue
+		}
+
+		values.Add(name, valueRepr(sv, opts, sf))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func valueRepr(v reflect.Value, opts tagOptions, sf reflect.StructField) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		if opts.Contains("unixmilli") {
+			return strconv.FormatInt(t.UnixMilli(), 10)
+		}
+		if opts.Contains("unixnano") {
+			return strconv.FormatInt(t.UnixNano(), 10)
+		}
+		if layout := sf.Tag.Get("layout"); layout != "" {
+			return t.Format(layout)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	type zeroable interface {
+		IsZero() bool
+	}
+
+	if z, ok := v.Interface().(zeroable); ok {
+		return z.IsZero()
+	}
+
+	return false
+}
+
+//===========================================================================
+// Tag Parsing
+//===========================================================================
+
+// tagOptions is the string following a comma in a struct field's "url" tag,
+// or the empty string. It does not include the leading comma.
+type tagOptions []string
+
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+func (o tagOptions) Contains(opt string) bool {
+	for _, option := range o {
+		if option == opt {
+			return true
+		}
+	}
+	return false
+}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1,0 +1,742 @@
+// Tests ported from https://github.com/google/go-querystring
+// Copyright (c) 2013 Google. All rights reserved.
+package query
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.rtnl.ai/x/assert"
+)
+
+// test that Values(input) matches want.  If not, report an error on t.
+func testValue(i int, t *testing.T, input interface{}, want url.Values) {
+	t.Helper()
+	v, err := Values(input)
+	assert.Ok(t, err, "test case %d failed with error", i)
+	assert.Equal(t, want, v, "test case %d failed with mismatched values", i)
+}
+
+func TestValues_BasicTypes(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		// zero values
+		{struct{ V string }{}, url.Values{"V": {""}}},
+		{struct{ V int }{}, url.Values{"V": {"0"}}},
+		{struct{ V uint }{}, url.Values{"V": {"0"}}},
+		{struct{ V float32 }{}, url.Values{"V": {"0"}}},
+		{struct{ V bool }{}, url.Values{"V": {"false"}}},
+
+		// simple non-zero values
+		{struct{ V string }{"v"}, url.Values{"V": {"v"}}},
+		{struct{ V int }{1}, url.Values{"V": {"1"}}},
+		{struct{ V uint }{1}, url.Values{"V": {"1"}}},
+		{struct{ V float32 }{0.1}, url.Values{"V": {"0.1"}}},
+		{struct{ V bool }{true}, url.Values{"V": {"true"}}},
+
+		// bool-specific options
+		{
+			struct {
+				V bool `url:",int"`
+			}{false},
+			url.Values{"V": {"0"}},
+		},
+		{
+			struct {
+				V bool `url:",int"`
+			}{true},
+			url.Values{"V": {"1"}},
+		},
+
+		// time values
+		{
+			struct {
+				V time.Time
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"2000-01-01T12:34:56Z"}},
+		},
+		{
+			struct {
+				V time.Time `url:",unix"`
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"946730096"}},
+		},
+		{
+			struct {
+				V time.Time `url:",unixmilli"`
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"946730096000"}},
+		},
+		{
+			struct {
+				V time.Time `url:",unixnano"`
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"946730096000000000"}},
+		},
+		{
+			struct {
+				V time.Time `layout:"2006-01-02"`
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"2000-01-01"}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestValues_Pointers(t *testing.T) {
+	str := "s"
+	strPtr := &str
+
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		// nil pointers (zero values)
+		{struct{ V *string }{}, url.Values{"V": {""}}},
+		{struct{ V *int }{}, url.Values{"V": {""}}},
+
+		// non-zero pointer values
+		{struct{ V *string }{&str}, url.Values{"V": {"s"}}},
+		{struct{ V **string }{&strPtr}, url.Values{"V": {"s"}}},
+
+		// slices of pointer values
+		{struct{ V []*string }{}, url.Values{}},
+		{struct{ V []*string }{[]*string{&str, &str}}, url.Values{"V": {"s", "s"}}},
+
+		// pointer to slice
+		{struct{ V *[]string }{}, url.Values{"V": {""}}},
+		{struct{ V *[]string }{&[]string{"a", "b"}}, url.Values{"V": {"a", "b"}}},
+
+		// pointer values for the input struct itself
+		{(*struct{})(nil), url.Values{}},
+		{&struct{}{}, url.Values{}},
+		{&struct{ V string }{}, url.Values{"V": {""}}},
+		{&struct{ V string }{"v"}, url.Values{"V": {"v"}}},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestValues_Slices(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		// slices of strings
+		{
+			struct{ V []string }{},
+			url.Values{},
+		},
+		{
+			struct{ V []string }{[]string{}},
+			url.Values{},
+		},
+		{
+			struct{ V []string }{[]string{""}},
+			url.Values{"V": {""}},
+		},
+		{
+			struct{ V []string }{[]string{"a", "b"}},
+			url.Values{"V": {"a", "b"}},
+		},
+		{
+			struct {
+				V []string `url:",comma"`
+			}{[]string{}},
+			url.Values{},
+		},
+		{
+			struct {
+				V []string `url:",comma"`
+			}{[]string{""}},
+			url.Values{"V": {""}},
+		},
+		{
+			struct {
+				V []string `url:",comma"`
+			}{[]string{"a", "b"}},
+			url.Values{"V": {"a,b"}},
+		},
+		{
+			struct {
+				V []string `url:",space"`
+			}{[]string{"a", "b"}},
+			url.Values{"V": {"a b"}},
+		},
+		{
+			struct {
+				V []string `url:",semicolon"`
+			}{[]string{"a", "b"}},
+			url.Values{"V": {"a;b"}},
+		},
+		{
+			struct {
+				V []string `url:",brackets"`
+			}{[]string{"a", "b"}},
+			url.Values{"V[]": {"a", "b"}},
+		},
+		{
+			struct {
+				V []string `url:",numbered"`
+			}{[]string{"a", "b"}},
+			url.Values{"V0": {"a"}, "V1": {"b"}},
+		},
+
+		// arrays of strings
+		{
+			struct{ V [2]string }{},
+			url.Values{"V": {"", ""}},
+		},
+		{
+			struct{ V [2]string }{[2]string{"a", "b"}},
+			url.Values{"V": {"a", "b"}},
+		},
+		{
+			struct {
+				V [2]string `url:",comma"`
+			}{[2]string{"a", "b"}},
+			url.Values{"V": {"a,b"}},
+		},
+		{
+			struct {
+				V [2]string `url:",space"`
+			}{[2]string{"a", "b"}},
+			url.Values{"V": {"a b"}},
+		},
+		{
+			struct {
+				V [2]string `url:",semicolon"`
+			}{[2]string{"a", "b"}},
+			url.Values{"V": {"a;b"}},
+		},
+		{
+			struct {
+				V [2]string `url:",brackets"`
+			}{[2]string{"a", "b"}},
+			url.Values{"V[]": {"a", "b"}},
+		},
+		{
+			struct {
+				V [2]string `url:",numbered"`
+			}{[2]string{"a", "b"}},
+			url.Values{"V0": {"a"}, "V1": {"b"}},
+		},
+
+		// custom delimiters
+		{
+			struct {
+				V []string `del:","`
+			}{[]string{"a", "b"}},
+			url.Values{"V": {"a,b"}},
+		},
+		{
+			struct {
+				V []string `del:"|"`
+			}{[]string{"a", "b"}},
+			url.Values{"V": {"a|b"}},
+		},
+		{
+			struct {
+				V []string `del:"🥑"`
+			}{[]string{"a", "b"}},
+			url.Values{"V": {"a🥑b"}},
+		},
+
+		// slice of bools with additional options
+		{
+			struct {
+				V []bool `url:",space,int"`
+			}{[]bool{true, false}},
+			url.Values{"V": {"1 0"}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestValues_NestedTypes(t *testing.T) {
+	type SubNested struct {
+		Value string `url:"value"`
+	}
+
+	type Nested struct {
+		A   SubNested  `url:"a"`
+		B   *SubNested `url:"b"`
+		Ptr *SubNested `url:"ptr,omitempty"`
+	}
+
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{
+			struct {
+				Nest Nested `url:"nest"`
+			}{
+				Nested{
+					A: SubNested{
+						Value: "v",
+					},
+				},
+			},
+			url.Values{
+				"nest[a][value]": {"v"},
+				"nest[b]":        {""},
+			},
+		},
+		{
+			struct {
+				Nest Nested `url:"nest"`
+			}{
+				Nested{
+					Ptr: &SubNested{
+						Value: "v",
+					},
+				},
+			},
+			url.Values{
+				"nest[a][value]":   {""},
+				"nest[b]":          {""},
+				"nest[ptr][value]": {"v"},
+			},
+		},
+		{
+			nil,
+			url.Values{},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestValues_OmitEmpty(t *testing.T) {
+	str := ""
+
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{struct{ v string }{}, url.Values{}}, // non-exported field
+		{
+			struct {
+				V string `url:",omitempty"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V string `url:"-"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V string `url:"omitempty"` // actually named omitempty
+			}{},
+			url.Values{"omitempty": {""}},
+		},
+		{
+			// include value for a non-nil pointer to an empty value
+			struct {
+				V *string `url:",omitempty"`
+			}{&str},
+			url.Values{"V": {""}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestValues_EmbeddedStructs(t *testing.T) {
+	type Inner struct {
+		V string
+	}
+	type Outer struct {
+		Inner
+	}
+	type OuterPtr struct {
+		*Inner
+	}
+	type Mixed struct {
+		Inner
+		V string
+	}
+	type unexported struct {
+		Inner
+		V string
+	}
+	type Exported struct {
+		unexported
+	}
+
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{
+			Outer{Inner{V: "a"}},
+			url.Values{"V": {"a"}},
+		},
+		{
+			OuterPtr{&Inner{V: "a"}},
+			url.Values{"V": {"a"}},
+		},
+		{
+			Mixed{Inner: Inner{V: "a"}, V: "b"},
+			url.Values{"V": {"b", "a"}},
+		},
+		{
+			// values from unexported embed are still included
+			Exported{
+				unexported{
+					Inner: Inner{V: "bar"},
+					V:     "foo",
+				},
+			},
+			url.Values{"V": {"foo", "bar"}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestValues_InvalidInput(t *testing.T) {
+	_, err := Values("")
+	if err == nil {
+		t.Errorf("expected Values() to return an error on invalid input")
+	}
+}
+
+// customEncodedStrings is a slice of strings with a custom URL encoding
+type customEncodedStrings []string
+
+// EncodeValues using key name of the form "{key}.N" where N increments with
+// each value.  A value of "err" will return an error.
+func (m customEncodedStrings) EncodeValues(key string, v *url.Values) error {
+	for i, arg := range m {
+		if arg == "err" {
+			return errors.New("encoding error")
+		}
+		v.Set(fmt.Sprintf("%s.%d", key, i), arg)
+	}
+	return nil
+}
+
+func TestValues_CustomEncodingSlice(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{
+			struct {
+				V customEncodedStrings `url:"v"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V customEncodedStrings `url:"v"`
+			}{[]string{"a", "b"}},
+			url.Values{"v.0": {"a"}, "v.1": {"b"}},
+		},
+
+		// pointers to custom encoded types
+		{
+			struct {
+				V *customEncodedStrings `url:"v"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V *customEncodedStrings `url:"v"`
+			}{(*customEncodedStrings)(&[]string{"a", "b"})},
+			url.Values{"v.0": {"a"}, "v.1": {"b"}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+// One of the few ways reflectValues will return an error is if a custom
+// encoder returns an error.  Test all of the various ways that can happen.
+func TestValues_CustomEncoding_Error(t *testing.T) {
+	type st struct {
+		V customEncodedStrings
+	}
+	tests := []struct {
+		input interface{}
+	}{
+		{
+			st{[]string{"err"}},
+		},
+		{ // struct field
+			struct{ S st }{st{[]string{"err"}}},
+		},
+		{ // embedded struct
+			struct{ st }{st{[]string{"err"}}},
+		},
+	}
+	for _, tt := range tests {
+		_, err := Values(tt.input)
+		if err == nil {
+			t.Errorf("Values(%q) did not return expected encoding error", tt.input)
+		}
+	}
+}
+
+// customEncodedInt is an int with a custom URL encoding
+type customEncodedInt int
+
+// EncodeValues encodes values with leading underscores
+func (m customEncodedInt) EncodeValues(key string, v *url.Values) error {
+	v.Set(key, fmt.Sprintf("_%d", m))
+	return nil
+}
+
+func TestValues_CustomEncodingInt(t *testing.T) {
+	var zero customEncodedInt = 0
+	var one customEncodedInt = 1
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{
+			struct {
+				V customEncodedInt `url:"v"`
+			}{},
+			url.Values{"v": {"_0"}},
+		},
+		{
+			struct {
+				V customEncodedInt `url:"v,omitempty"`
+			}{zero},
+			url.Values{},
+		},
+		{
+			struct {
+				V customEncodedInt `url:"v"`
+			}{one},
+			url.Values{"v": {"_1"}},
+		},
+
+		// pointers to custom encoded types
+		{
+			struct {
+				V *customEncodedInt `url:"v"`
+			}{},
+			url.Values{"v": {"_0"}},
+		},
+		{
+			struct {
+				V *customEncodedInt `url:"v,omitempty"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V *customEncodedInt `url:"v,omitempty"`
+			}{&zero},
+			url.Values{"v": {"_0"}},
+		},
+		{
+			struct {
+				V *customEncodedInt `url:"v"`
+			}{&one},
+			url.Values{"v": {"_1"}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+// customEncodedInt is an int with a custom URL encoding defined on its pointer
+// value.
+type customEncodedIntPtr int
+
+// EncodeValues encodes a 0 as false, 1 as true, and nil as unknown.  All other
+// values cause an error.
+func (m *customEncodedIntPtr) EncodeValues(key string, v *url.Values) error {
+	if m == nil {
+		v.Set(key, "undefined")
+	} else {
+		v.Set(key, fmt.Sprintf("_%d", *m))
+	}
+	return nil
+}
+
+// Test behavior when encoding is defined for a pointer of a custom type.
+// Custom type should be able to encode values for nil pointers.
+func TestValues_CustomEncodingPointer(t *testing.T) {
+	var zero customEncodedIntPtr = 0
+	var one customEncodedIntPtr = 1
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		// non-pointer values do not get the custom encoding because
+		// they don't implement the encoder interface.
+		{
+			struct {
+				V customEncodedIntPtr `url:"v"`
+			}{},
+			url.Values{"v": {"0"}},
+		},
+		{
+			struct {
+				V customEncodedIntPtr `url:"v,omitempty"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V customEncodedIntPtr `url:"v"`
+			}{one},
+			url.Values{"v": {"1"}},
+		},
+
+		// pointers to custom encoded types.
+		{
+			struct {
+				V *customEncodedIntPtr `url:"v"`
+			}{},
+			url.Values{"v": {"undefined"}},
+		},
+		{
+			struct {
+				V *customEncodedIntPtr `url:"v,omitempty"`
+			}{},
+			url.Values{},
+		},
+		{
+			struct {
+				V *customEncodedIntPtr `url:"v"`
+			}{&zero},
+			url.Values{"v": {"_0"}},
+		},
+		{
+			struct {
+				V *customEncodedIntPtr `url:"v,omitempty"`
+			}{&zero},
+			url.Values{"v": {"_0"}},
+		},
+		{
+			struct {
+				V *customEncodedIntPtr `url:"v"`
+			}{&one},
+			url.Values{"v": {"_1"}},
+		},
+	}
+
+	for i, tt := range tests {
+		testValue(i, t, tt.input, tt.want)
+	}
+}
+
+func TestIsEmptyValue(t *testing.T) {
+	str := "string"
+	tests := []struct {
+		value interface{}
+		empty bool
+	}{
+		// slices, arrays, and maps
+		{[]int{}, true},
+		{[]int{0}, false},
+		{[0]int{}, true},
+		{[3]int{}, false},
+		{[3]int{1}, false},
+		{map[string]string{}, true},
+		{map[string]string{"a": "b"}, false},
+
+		// strings
+		{"", true},
+		{" ", false},
+		{"a", false},
+
+		// bool
+		{true, false},
+		{false, true},
+
+		// ints of various types
+		{(int)(0), true}, {(int)(1), false}, {(int)(-1), false},
+		{(int8)(0), true}, {(int8)(1), false}, {(int8)(-1), false},
+		{(int16)(0), true}, {(int16)(1), false}, {(int16)(-1), false},
+		{(int32)(0), true}, {(int32)(1), false}, {(int32)(-1), false},
+		{(int64)(0), true}, {(int64)(1), false}, {(int64)(-1), false},
+		{(uint)(0), true}, {(uint)(1), false},
+		{(uint8)(0), true}, {(uint8)(1), false},
+		{(uint16)(0), true}, {(uint16)(1), false},
+		{(uint32)(0), true}, {(uint32)(1), false},
+		{(uint64)(0), true}, {(uint64)(1), false},
+
+		// floats
+		{(float32)(0), true}, {(float32)(0.0), true}, {(float32)(0.1), false},
+		{(float64)(0), true}, {(float64)(0.0), true}, {(float64)(0.1), false},
+
+		// pointers
+		{(*int)(nil), true},
+		{new([]int), false},
+		{&str, false},
+
+		// time
+		{time.Time{}, true},
+		{time.Now(), false},
+
+		// unknown type - always false unless a nil pointer, which are always empty.
+		{(*struct{ int })(nil), true},
+		{struct{ int }{}, false},
+		{struct{ int }{0}, false},
+		{struct{ int }{1}, false},
+	}
+
+	for _, tt := range tests {
+		got := isEmptyValue(reflect.ValueOf(tt.value))
+		want := tt.empty
+		if got != want {
+			t.Errorf("isEmptyValue(%v) returned %t; want %t", tt.value, got, want)
+		}
+	}
+}
+
+func TestParseTag(t *testing.T) {
+	name, opts := parseTag("field,foobar,foo")
+	if name != "field" {
+		t.Fatalf("name = %q, want field", name)
+	}
+	for _, tt := range []struct {
+		opt  string
+		want bool
+	}{
+		{"foobar", true},
+		{"foo", true},
+		{"bar", false},
+		{"field", false},
+	} {
+		if opts.Contains(tt.opt) != tt.want {
+			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+		}
+	}
+}


### PR DESCRIPTION
### Scope of changes

Implements the `Query` package for encoding struct values as URL query params.

Fixes SC-34391

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have added new test fixtures as needed to support added tests