### PR TITLE
Key based locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is single repository that stores many, independent small subpackages. This 
 - [gravatar](https://go.rtnl.ai/x/gravatar): helper to create Gravatar urls from email addresses
 - [httpcc](https://go.rtnl.ai/x/httpcc): http cache control header parsing and directives management
 - [humanize](https://go.rtnl.ai/x/humanize): creates human readable strings from various types
+- [locks](https://go.rtnl.ai/x/locks): key-based lock mechanism to distribute keys across a fixed number of locks
 - [noplog](https://go.rtnl.ai/x/noplog): no operation logger to capture internal logging with no output
 - [out](https://go.rtnl.ai/x/out): hierarchical logger to manage logging verbosity to stdout
 - [probez](https://go.rtnl.ai/x/probez): http handlers for kubernetes probes (livez, healthz, and readyz)

--- a/locks/README.md
+++ b/locks/README.md
@@ -1,0 +1,48 @@
+# Locks
+
+The locks package implements a key-based lock mechanism that uses a crc32 hash to
+distribute keys across a fixed number of locks. This allows for concurrent access
+to different keys without contention, but fixes the number of locks (and therefore the
+amount of available concurrency) to ensure that memory usage is bounded.
+
+Locks help us implement simple transactions for the storage engine. At the start of a
+transaction before any other operation is performed, the transaction must acquire
+its read and write locks to all keys it wants to access in the transaction. The locks
+are acquired in a consistent order to prevent deadlocks.
+
+Reference: [Handling Deadlocks in Golang Gracefully](https://medium.com/@ksandeeptech07/handling-deadlocks-in-golang-gracefully-1f661c341a1d)
+
+## Usage
+
+Create a new key lock with a fixed number of locks. The greater `nlocks` is, the greater concurrency there is across the entire key space at the cost of more memory. I recommend allocating at least 1024 locks to ensure suitable performance.
+
+```golang
+mu := locks.New(1024)
+```
+
+You can acquire locks or read locks for a set of keys. Note that the same exact keyset should be unlocked all at once and multiple calls to lock in the same go routine should be avoided.
+
+```golang
+func Update(ids []ulid.ULID, value []byte) {
+    keys := make([][]byte, 0, len(ids))
+    for _, id := range ids {
+        keys = append(keys, id[:])
+    }
+
+    mu.Lock(keys...)
+    defer mu.Unlock(keys...)
+
+}
+
+func Fetch(ids []ulid.ULID) {
+    keys := make([][]byte, 0, len(ids))
+    for _, id := range ids {
+        keys = append(keys, id[:])
+    }
+
+    mu.RLock(keys...)
+    defer mu.RUnlock(keys...)
+}
+```
+
+The lock function itself will sort the keys to ensure the keys are unlocked in the same order so no sorting is required from the user.

--- a/locks/locks.go
+++ b/locks/locks.go
@@ -1,0 +1,229 @@
+/*
+The locks package implements a key-based lock mechanism that uses a crc32 hash to
+distribute keys across a fixed number of locks. This allows for concurrent access
+to different keys without contention, but fixes the number of locks (and therefore the
+amount of available concurrency) to ensure that memory usage is bounded.
+
+Locks help us implement simple transactions for the storage engine. At the start of a
+transaction before any other operation is performed, the transaction must acquire
+its read and write locks to all keys it wants to access in the transaction. The locks
+are acquired in a consistent order to prevent deadlocks.
+
+Reference: https://medium.com/@ksandeeptech07/handling-deadlocks-in-golang-gracefully-1f661c341a1d
+*/
+package locks
+
+import (
+	"hash/crc32"
+	"sort"
+	"sync"
+)
+
+const DefaultCount = 1024
+
+type Keys interface {
+	Lock(...[]byte)
+	Unlock(...[]byte)
+	RLock(...[]byte)
+	RUnlock(...[]byte)
+	LockAll()
+	UnlockAll()
+	RLockAll()
+	RUnlockAll()
+	Index([]byte) int
+	Indices(...[]byte) []int
+}
+
+// KeyLocks are used to prevent concurrent writes to the same key and to allow multiple
+// concurrent reads using a sync.RWMutex. The keys are distributed across a fixed number
+// of mutexes to preven unbounded memory growth; so it is possible that two different
+// keys will share the same lock. Collection keys (keys without object ids or versions),
+// object prefix keys, and specific version keys are all locked with the same data
+// structure.
+//
+// In a storage transaction, the transaction must acquire its read and write locks to
+// all keys it wants to access in the transaction. The locks are acquired and released
+// in a consistent order to prevent deadlocks. Multi-key locks must be acquired and
+// released at the same time without multiple calls to Lock or RLock.
+type KeyLock struct {
+	count uint32
+	locks []sync.RWMutex
+	table *crc32.Table
+}
+
+var _ Keys = (*KeyLock)(nil)
+
+// Create a new KeyLock with the given number of locks. The greater nlocks is, the
+// greater concurrency there is across the entire key space at the cost of more memory.
+// We recommend allocating at least 1024 locks to ensure suitable performance.
+func New(nlocks uint32) *KeyLock {
+	if nlocks == 0 {
+		nlocks = DefaultCount
+	}
+
+	return &KeyLock{
+		count: nlocks,
+		locks: make([]sync.RWMutex, nlocks),
+		table: crc32.MakeTable(crc32.Koopman),
+	}
+}
+
+// Acquire a write lock for the given keys. Note that the same exact keyset should be
+// unlocked all at once using the Unlock function and multiple calls to Lock before
+// unlocking should be avoided.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) Lock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].Lock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].Lock()
+		}
+	}
+}
+
+// Unlock the write lock for the specified keys. Note that the same exact keyset should
+// be unlocked all at once using the Unlock function before any calls to Lock or RLock.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) Unlock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].Unlock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].Unlock()
+		}
+	}
+}
+
+// Acquire a read lock for the given keys. Multiple read locks can be acquired
+// concurrently, but a write lock cannot be acquired while any read locks are held and
+// no read locks can be acquired while a write lock is held. The same exact keyset
+// should be used with RUnlock to release the read locks and multiple calls to RLock or
+// Lock before unlocking should be avoided.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) RLock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].RLock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].RLock()
+		}
+	}
+}
+
+// Release a read lock for the specified keys. Note that the same exact keyset should
+// be unlocked all at once using the RUnlock function before any calls to Lock or RLock.
+//
+// The locks associated with the keys are identified by the index function, which is
+// deduplicated and sorted so that the highest index lock is always acquired first. As
+// long as the order of acquisition is consistent between different goroutines, you
+// won't get deadlocks, even for arbitrary subsets of the locks.
+func (k *KeyLock) RUnlock(keys ...[]byte) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		k.locks[crc32.Checksum(keys[0], k.table)%k.count].RUnlock()
+	default:
+		indices := k.Indices(keys...)
+		for _, index := range indices {
+			k.locks[index].RUnlock()
+		}
+	}
+}
+
+// Return the index of the lock for the given key (useful for debugging).
+func (k *KeyLock) Index(key []byte) int {
+	return int(crc32.Checksum(key, k.table) % k.count)
+}
+
+// Return a sorted, deduplicated slice of indices for the specified keys.
+func (k *KeyLock) Indices(keys ...[]byte) (out []int) {
+	// Find all indices associated with the keys
+	out = make([]int, len(keys))
+	for i, key := range keys {
+		out[i] = int(crc32.Checksum(key, k.table) % k.count)
+	}
+
+	// Return the indices if there are no duplicates
+	if len(out) < 2 {
+		return out
+	}
+
+	// Deduplicate the indices to ensure that within a keyspace, there is no locking
+	// deadlock (e.g. if we ask for locks for two keys with the same index in the same
+	// goroutine we would deadlock if we didn't deduplicate).
+	// Slice sort based deduplication is faster than map based deduplication.
+	sort.Slice(out, func(i, j int) bool { return out[i] > out[j] })
+	var e = 1
+	for i := 1; i < len(out); i++ {
+		if out[i] == out[i-1] {
+			continue
+		}
+		out[e] = out[i]
+		e++
+	}
+	return out[:e]
+}
+
+// Sequentially locks all indices in the KeyLock. This will prevent any other process
+// from acquiring any locks at all. Because locks are acquired with the highest index
+// first, this will not deadlock with any other goroutine that is acquiring locks in
+// the same order.
+func (k *KeyLock) LockAll() {
+	for i := len(k.locks) - 1; i >= 0; i-- {
+		k.locks[i].Lock()
+	}
+}
+
+// Sequentially unlocks all indices in the KeyLock. This method does not detect if a
+// lock is unlocked and will panic if it is not; therefore this method should only be
+// called after LockAll() and not as a method to release any held locks.
+func (k *KeyLock) UnlockAll() {
+	for i := len(k.locks) - 1; i >= 0; i-- {
+		k.locks[i].Unlock()
+	}
+}
+
+// Sequentially read locks all indices in the KeyLock. This will prevent any other
+// process from acquiring any write locks. Because locks are acquired with the highest
+// index first, this will not deadlock with any other goroutine that is acquiring
+// locks in the same order.
+func (k *KeyLock) RLockAll() {
+	for i := len(k.locks) - 1; i >= 0; i-- {
+		k.locks[i].RLock()
+	}
+}
+
+// Sequentially read unlocks all indices in the KeyLock. This method does not detect if
+// a lock is unlocked and will panic if it is not; therefore this method should only be
+// called after ReadLockAll() and not as a method to release any held locks.
+func (k *KeyLock) RUnlockAll() {
+	for i := len(k.locks) - 1; i >= 0; i-- {
+		k.locks[i].RUnlock()
+	}
+}

--- a/locks/locks_test.go
+++ b/locks/locks_test.go
@@ -1,0 +1,337 @@
+package locks_test
+
+import (
+	"crypto/rand"
+	random "math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"go.rtnl.ai/x/assert"
+	"go.rtnl.ai/x/locks"
+)
+
+func TestLocking(t *testing.T) {
+	mu := locks.New(0)
+	k1 := []byte{28, 38, 142, 19, 36, 13, 138, 224, 208, 120, 174, 202, 245, 249, 3, 170, 219, 30, 199, 222, 214, 181, 20, 190, 160, 228, 153, 169, 50, 227, 233, 158, 213, 202, 71, 43, 228, 172, 50, 245, 129, 145, 45, 241, 52}
+	k2 := []byte{130, 255, 26, 113, 234, 106, 222, 190, 243, 205, 105, 236, 252, 191, 170, 22, 103, 99, 205, 208, 252, 137, 32, 197, 180, 40, 46, 90, 120, 224, 109, 215, 124, 190, 67, 208, 114, 208, 64, 13, 144, 88, 188, 112, 144}
+	k3 := []byte{43, 190, 204, 198, 110, 31, 120, 141, 165, 0, 172, 63, 39, 97, 37, 6, 189, 186, 23, 208, 124, 212, 163, 232, 153, 81, 105, 133, 147, 247, 192, 66, 253, 243, 163, 225, 35, 22, 230, 42, 55, 4, 83, 74, 240}
+
+	t.Run("NoKey", func(t *testing.T) {
+		mu.Lock()
+		mu.Unlock()
+
+		mu.RLock()
+		mu.RLock()
+		mu.RLock()
+
+		mu.RUnlock()
+		mu.RUnlock()
+		mu.RUnlock()
+	})
+
+	t.Run("Single", func(t *testing.T) {
+		// Make sure the three keys have different indexes or this test will fail.
+		assert.NotEqual(t, mu.Index(k1), mu.Index(k2))
+		assert.NotEqual(t, mu.Index(k1), mu.Index(k3))
+		assert.NotEqual(t, mu.Index(k2), mu.Index(k3))
+
+		mu.Lock(k1)
+		mu.Lock(k2)
+		mu.Lock(k3)
+
+		mu.Unlock(k2)
+		mu.RLock(k2)
+		mu.RLock(k2)
+		mu.RLock(k2)
+
+		mu.RUnlock(k2)
+		mu.RUnlock(k2)
+		mu.RUnlock(k2)
+
+		mu.Unlock(k1)
+		mu.Unlock(k3)
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		mu.Lock(k1, k2, k3)
+		mu.Unlock(k1, k2, k3)
+
+		mu.RLock(k1, k2, k3)
+		mu.RLock(k1, k2, k3)
+		mu.RLock(k1, k2, k3)
+
+		mu.RUnlock(k1, k2, k3)
+		mu.RUnlock(k1, k2, k3)
+		mu.RUnlock(k1, k2, k3)
+	})
+
+	t.Run("All", func(t *testing.T) {
+		mu.LockAll()
+		mu.UnlockAll()
+
+		mu.RLockAll()
+		mu.RLockAll()
+		mu.RLockAll()
+
+		mu.RUnlockAll()
+		mu.RUnlockAll()
+		mu.RUnlockAll()
+
+		mu.LockAll()
+		mu.UnlockAll()
+	})
+}
+
+func TestContention(t *testing.T) {
+	var (
+		writers    = 64
+		writes     = 256
+		writesleep = 32
+		readers    = 256
+		reads      = 512
+		readsleep  = 16
+		keyspace   = 512
+		locksize   = 128
+	)
+
+	t.Run("NoKey", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
+
+		wg.Add(writers)
+		for range writers {
+			go func() {
+				defer wg.Done()
+				for range writes {
+					mu.Lock()
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.Unlock()
+				}
+			}()
+		}
+
+		wg.Add(readers)
+		for range readers {
+			go func() {
+				defer wg.Done()
+				for range reads {
+					mu.RLock()
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlock()
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("Single", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
+
+		keys := make([][]byte, keyspace)
+		for i := range keyspace {
+			keys[i] = RandomKey()
+		}
+
+		wg.Add(writers)
+		for range writers {
+			go func() {
+				defer wg.Done()
+				k := keys[random.IntN(len(keys))]
+
+				for range writes {
+					mu.Lock(k)
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.Unlock(k)
+				}
+			}()
+		}
+
+		wg.Add(readers)
+		for range readers {
+			go func() {
+				defer wg.Done()
+				k := keys[random.IntN(len(keys))]
+
+				for range reads {
+					mu.RLock(k)
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlock(k)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
+
+		keys := make([][]byte, keyspace)
+		for i := range keyspace {
+			keys[i] = RandomKey()
+		}
+
+		wg.Add(writers)
+		for range writers {
+			go func() {
+				defer wg.Done()
+
+				n := random.IntN(32)
+				ks := make([][]byte, n)
+				for j := range n {
+					ks[j] = keys[random.IntN(len(keys))]
+				}
+
+				for range writes {
+					mu.Lock(ks...)
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.Unlock(ks...)
+				}
+			}()
+		}
+
+		wg.Add(readers)
+		for range readers {
+			go func() {
+				defer wg.Done()
+
+				n := random.IntN(32)
+				ks := make([][]byte, n)
+				for j := range n {
+					ks[j] = keys[random.IntN(len(keys))]
+				}
+
+				for range reads {
+					mu.RLock(ks...)
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlock(ks...)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("All", func(t *testing.T) {
+		mu := locks.New(uint32(locksize))
+		wg := sync.WaitGroup{}
+
+		wg.Add(2)
+		for range 2 {
+			go func() {
+				defer wg.Done()
+				for range 8 {
+					mu.LockAll()
+					time.Sleep(time.Duration(random.IntN(writesleep)) * time.Microsecond)
+					mu.UnlockAll()
+				}
+			}()
+		}
+
+		wg.Add(16)
+		for range 16 {
+			go func() {
+				defer wg.Done()
+				for range 32 {
+					mu.RLockAll()
+					time.Sleep(time.Duration(random.IntN(readsleep)) * time.Microsecond)
+					mu.RUnlockAll()
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestIndices(t *testing.T) {
+	t.Run("NoDuplicates", func(t *testing.T) {
+		mu := locks.New(128)
+		keys := [][]byte{
+			{1, 2, 3},
+			{4, 5, 6},
+			{7, 8, 9},
+		}
+
+		indices := mu.Indices(keys...)
+		assert.Equal(t, []int{81, 42, 20}, indices)
+	})
+
+	t.Run("Duplicates", func(t *testing.T) {
+		mu := locks.New(8)
+		keys := make([][]byte, 128)
+		for i := 0; i < 128; i++ {
+			keys[i] = RandomKey()
+		}
+
+		indices := mu.Indices(keys...)
+		assert.Equal(t, []int{7, 6, 5, 4, 3, 2, 1, 0}, indices)
+	})
+
+}
+
+func BenchmarkLocks(b *testing.B) {
+	keys := make([][]byte, 128)
+	for i := 0; i < 128; i++ {
+		keys[i] = RandomKey()
+	}
+
+	runContention := func(f func([]byte)) {
+		wg := sync.WaitGroup{}
+		wg.Add(1024)
+		for i := 0; i < 1024; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 512; j++ {
+					k := keys[random.IntN(128)]
+					f(k)
+				}
+			}()
+		}
+		wg.Wait()
+	}
+
+	b.Run("Sync", func(b *testing.B) {
+		var mu sync.Mutex
+		for i := 0; i < b.N; i++ {
+			runContention(func(k []byte) {
+				mu.Lock()
+				_ = len(k)
+				mu.Unlock()
+			})
+		}
+	})
+
+	b.Run("KeyLock128", func(b *testing.B) {
+		mu := locks.New(128)
+		for i := 0; i < b.N; i++ {
+			runContention(func(k []byte) {
+				mu.Lock(k)
+				_ = len(k)
+				mu.Unlock(k)
+			})
+		}
+	})
+
+	b.Run("KeyLock1024", func(b *testing.B) {
+		mu := locks.New(1024)
+		for i := 0; i < b.N; i++ {
+			runContention(func(k []byte) {
+				mu.Lock(k)
+				_ = len(k)
+				mu.Unlock(k)
+			})
+		}
+	})
+
+}
+
+func RandomKey() []byte {
+	k := make([]byte, 45)
+	rand.Read(k)
+	return k
+}


### PR DESCRIPTION
### Scope of changes

The locks package implements a key-based lock mechanism that uses a crc32 hash to
distribute keys across a fixed number of locks. This allows for concurrent access
to different keys without contention, but fixes the number of locks (and therefore the
amount of available concurrency) to ensure that memory usage is bounded.

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have added new test fixtures as needed to support added tests
